### PR TITLE
Fix compatibility issues with clang-20.

### DIFF
--- a/chess-engine-lib/EvalParams.cpp
+++ b/chess-engine-lib/EvalParams.cpp
@@ -1,10 +1,11 @@
 #include "EvalParams.h"
 
 #include "Piece.h"
+#include "RangePatches.h"
 
+#include <format>
 #include <ranges>
 #include <sstream>
-#include <format>
 
 #include <cstring>
 
@@ -240,17 +241,15 @@ void writeTropismTable(
 
 template <std::size_t N>
 std::string arrayToString(const std::array<TaperedTerm, N>& valueArray) {
-    std::string inner = valueArray | std::ranges::views::transform(taperedTermToString)
-                      | std::ranges::views::join_with(std ::string(", "))
-                      | std::ranges::to<std::string>();
+    std::string inner =
+            valueArray | std::ranges::views::transform(taperedTermToString) | joinToString(", ");
     return "{" + inner + "}";
 }
 
 template <std::size_t N>
 std::string arrayToString(const std::array<EvalCalcT, N>& valueArray) {
-    std::string inner = valueArray | std::ranges::views::transform(evalCalcTToString)
-                      | std::ranges::views::join_with(std ::string(", "))
-                      | std::ranges::to<std::string>();
+    std::string inner =
+            valueArray | std::ranges::views::transform(evalCalcTToString) | joinToString(", ");
     return "{" + inner + "}";
 }
 

--- a/chess-engine-lib/FrontEndOption.cpp
+++ b/chess-engine-lib/FrontEndOption.cpp
@@ -1,6 +1,7 @@
 #include "FrontEndOption.h"
 
 #include "MyAssert.h"
+#include "RangePatches.h"
 
 #include <charconv>
 #include <format>
@@ -142,9 +143,7 @@ FrontEndOption FrontEndOption::createAlternative(
                      validValues = *option.validValues_](std::string_view valueString) {
         const auto it = std::find(validValues.begin(), validValues.end(), valueString);
         if (it == validValues.end()) {
-            const std::string validValuesString = validValues
-                                                | std::views::join_with(std::string(", "))
-                                                | std::ranges::to<std::string>();
+            const std::string validValuesString = validValues | joinToString(", ");
             throw std::invalid_argument(std::format(
                     "Invalid value '{}'. Expected one of: [{}]", valueString, validValuesString));
         }

--- a/chess-engine-lib/RangePatches.h
+++ b/chess-engine-lib/RangePatches.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+// Replacement for join_with and to<string>, necessary because of some clang-20 / libstdc++
+// compatibility issue.
+// Usage:
+//   range | joinToString(pattern)
+// Equivalent to:
+//   range | std::ranges::views::join_with(std::string_view(pattern)) | std::ranges::to<std::string>()
+
+struct JoinToString {
+    explicit JoinToString(std::string_view pattern) : pattern_(pattern) {}
+
+    template <typename R>
+    std::string operator()(R&& range) const {
+        std::string result;
+        bool first = true;
+        for (const auto& value : range) {
+            if (!first) {
+                result += pattern_;
+            }
+            result += value;
+            first = false;
+        }
+        return result;
+    }
+
+  private:
+    std::string_view pattern_;
+};
+
+inline JoinToString joinToString(std::string_view pattern) {
+    return JoinToString(pattern);
+}
+
+template <typename R>
+std::string operator|(R&& range, JoinToString f) {
+    return f(range);
+}
+
+// Replacement for to<T>, necessary because of some clang-20 / libstdc++ compatibility issue.
+// Usage:
+//   range | range_to<T>()
+// Equivalent to:
+//   range | std::ranges::to<T>()
+
+template <typename T>
+struct RangeTo {
+    template <typename R>
+    T operator()(R&& range) const {
+        T result{};
+        for (auto&& value : range) {
+            result.push_back(std::move(value));
+        }
+        return result;
+    }
+};
+
+template <typename T>
+RangeTo<T> range_to() {
+    return RangeTo<T>();
+}
+
+template <typename R, typename T>
+T operator|(R&& range, RangeTo<T> f) {
+    return f(range);
+}

--- a/chess-engine-lib/UciFrontEnd.cpp
+++ b/chess-engine-lib/UciFrontEnd.cpp
@@ -5,6 +5,7 @@
 #include "GameState.h"
 #include "Math.h"
 #include "MyAssert.h"
+#include "RangePatches.h"
 
 #include <future>
 #include <iostream>
@@ -20,8 +21,7 @@
 namespace {
 
 std::string moveListToString(const std::vector<Move>& moves) {
-    return moves | std::views::transform(&Move::toUci) | std::views::join_with(' ')
-         | std::ranges::to<std::string>();
+    return moves | std::views::transform(&Move::toUci) | joinToString(" ");
 }
 
 std::string scoreToString(const EvalT score) {
@@ -44,7 +44,7 @@ struct OptionStringParseResult {
 
 std::string stringToLower(std::string_view str) {
     return str | std::views::transform([](unsigned char c) { return std::tolower(c); })
-         | std::ranges::to<std::string>();
+         | range_to<std::string>();
 }
 
 }  // namespace
@@ -701,7 +701,7 @@ void UciFrontEnd::Impl::writeOptions() const {
                 const std::string varsString =
                         validValues
                         | std::views::transform([](auto v) { return std::format("var {}", v); })
-                        | std::views::join_with(' ') | std::ranges::to<std::string>();
+                        | joinToString(" ");
                 writeUci(
                         "option name {} type combo default {} {}",
                         name,

--- a/tuner/LoadPositions.cpp
+++ b/tuner/LoadPositions.cpp
@@ -1,5 +1,7 @@
 #include "LoadPositions.h"
 
+#include "chess-engine-lib/RangePatches.h"
+
 #include <execution>
 #include <fstream>
 #include <print>
@@ -124,5 +126,5 @@ std::vector<ScoredPosition> loadScoredPositions(
             });
 
     return std::ranges::views::join(nestedScoredPositions)
-         | std::ranges::to<std::vector<ScoredPosition>>();
+         | range_to<std::vector<ScoredPosition>>();
 }

--- a/tuner/Main.cpp
+++ b/tuner/Main.cpp
@@ -8,6 +8,7 @@
 #include "chess-engine-lib/Eval.h"
 #include "chess-engine-lib/GameState.h"
 #include "chess-engine-lib/Math.h"
+#include "chess-engine-lib/RangePatches.h"
 
 #include <filesystem>
 #include <format>
@@ -31,7 +32,7 @@ std::array<double, kNumEvalParams> getInitialParams() {
 
 std::string getParamsString(const std::array<double, kNumEvalParams>& paramsDouble) {
     return paramsDouble | std::ranges::views::transform([](double d) { return std::to_string(d); })
-         | std::ranges::views::join_with(std::string(", ")) | std::ranges::to<std::string>();
+         | joinToString(", ");
 }
 
 std::array<double, kNumPieceTypes - 1> getAveragePieceValues(

--- a/tuner/PreProcessing.cpp
+++ b/tuner/PreProcessing.cpp
@@ -3,6 +3,7 @@
 #include "chess-engine-lib/Eval.h"
 #include "chess-engine-lib/Math.h"
 #include "chess-engine-lib/MoveOrdering.h"
+#include "chess-engine-lib/RangePatches.h"
 
 #include <algorithm>
 #include <execution>
@@ -162,7 +163,7 @@ void quiescePositions(std::vector<ScoredPosition>& scoredPositions) {
                 return maybePosition.has_value();
             })
             | std::views::transform([](const auto& maybePosition) { return maybePosition.value(); })
-            | std::ranges::to<std::vector<ScoredPosition>>();
+            | range_to<std::vector<ScoredPosition>>();
 
     std::println("Obtained {} quiesced positions", quiescedPositions.size());
 


### PR DESCRIPTION
Clang-20, at least in combination with the libstdc++ that ships with Ubuntu 24.04, seems to have some issues with ranges.

Partially this could be addressed by switching join_with(string) to join_with(string_view). This seemingly compiles cleanly under all three major compilers: https://godbolt.org/z/67zE84bzs

However, the specific clang / libstdc++ combination seems to have issues with ranges::to. So it seems I'm forced to patch in custom versions for join_with and to.