### PR TITLE
Use precise FP semantics for consistent results across compilers/platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,9 @@ endif()
 
 # Set the architecture to AVX2 (and BMI2)
 if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2 /fp:contract")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2 /fp:precise")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -mbmi2 -ffp-contract=fast")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -mbmi2")
 endif()
 
 if (MSVC)

--- a/chess-engine/Main.cpp
+++ b/chess-engine/Main.cpp
@@ -22,7 +22,7 @@ int main() {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "Euwe v2.1.0");
+            UciFrontEnd uciFrontEnd(engine, "fp-precise");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
Confirmed on a test position (kiwipete) that searching to a fixed depth now leads to identical score / nodes / pv across all build configurations (linux/windows, msvc/gcc/clang/clang-cl, debug/release).

Explicitly adding the `/fp:precise` seems to be necessary for clang-cl to also adopt precise semantics (even though that should be the default value for that flag according to msvc documentation).

Passed non-regression SPRT (w/ -5 elo):
```
--------------------------------------------------
Results of fp-precise vs Euwe-v2.1.0 (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: 0.74 +/- 3.20, nElo: 1.12 +/- 4.84
LOS: 67.45 %, DrawRatio: 43.73 %, PairsRatio: 1.01
Games: 19778, Wins: 5516, Losses: 5474, Draws: 8788, Points: 9910.0 (50.11 %)
Ptnml(0-2): [504, 2262, 4324, 2286, 513], WL/DD Ratio: 1.04
LLR: 2.96 (100.7%) (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
SPRT ([-5.00, 0.00]) completed - H1 was accepted
```

Explicitly using FMA in `updateTaperedTerm` in Eval.cpp failed to pass improvement SPRT (w/ +3 elo):
```
--------------------------------------------------
Results of fp-precise-fma vs fp-precise (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: -0.85 +/- 2.18, nElo: -1.28 +/- 3.30
LOS: 22.32 %, DrawRatio: 43.46 %, PairsRatio: 1.00
Games: 42700, Wins: 11772, Losses: 11876, Draws: 19052, Points: 21298.0 (49.88 %)
Ptnml(0-2): [1137, 4911, 9278, 4967, 1057], WL/DD Ratio: 1.02
LLR: -2.95 (-100.2%) (-2.94, 2.94) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```