### PR TITLE
Bugfix: syzygy path validation on Linux

### DIFF
--- a/chess-engine-lib/Engine.cpp
+++ b/chess-engine-lib/Engine.cpp
@@ -214,8 +214,9 @@ EvalT Engine::Impl::evaluate(const GameState& gameState) const {
 
 void Engine::Impl::initializeSyzygy(std::string_view syzygyDir) {
     if (!syzygyPathIsValid(syzygyDir)) {
-        throw std::invalid_argument(
-                "invalid syzygy path. Must be a ;-separated list of directories.");
+        throw std::invalid_argument(std::format(
+                "invalid syzygy path. Must be a {}-separated list of directories.",
+                getSyzygyPathSeparator()));
     }
 
     if (hasSyzygy_) {

--- a/chess-engine-lib/Syzygy.cpp
+++ b/chess-engine-lib/Syzygy.cpp
@@ -38,11 +38,20 @@ namespace {
 
 }  // namespace
 
+char getSyzygyPathSeparator() {
+#ifdef _WIN32
+    return ';';
+#else
+    return ':';
+#endif
+}
+
 bool syzygyPathIsValid(std::string_view syzygyDirs) {
-    return std::ranges::all_of(syzygyDirs | std::views::split(';'), [](const auto& part) {
-        const std::filesystem::path p(part.begin(), part.end());
-        return std::filesystem::is_directory(p);
-    });
+    return std::ranges::all_of(
+            syzygyDirs | std::views::split(getSyzygyPathSeparator()), [](const auto& part) {
+                const std::filesystem::path p(part.begin(), part.end());
+                return std::filesystem::is_directory(p);
+            });
 }
 
 int initSyzygy(const std::string& syzygyDirs) {

--- a/chess-engine-lib/Syzygy.h
+++ b/chess-engine-lib/Syzygy.h
@@ -8,6 +8,8 @@
 #include "GameState.h"
 #include "Move.h"
 
+[[nodiscard]] char getSyzygyPathSeparator();
+
 [[nodiscard]] bool syzygyPathIsValid(std::string_view syzygyDirs);
 
 [[nodiscard]] int initSyzygy(const std::string& syzygyDirs);


### PR DESCRIPTION
Syzygy path validation incorrectly assumed that the paths should always be ;-separated, while they actually have to be :-separated on Linux. This made it impossible to load Syzygy TBs on Linux.

This PR fixes that.