### PR TITLE
Add sanitizer build modes & CI test runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         config_name: [x64-debug, x64-release, clang-x64-release]
 
+        include:
+        - os: ubuntu-latest
+          config_name: asan-ubsan
+        - os: ubuntu-latest
+          config_name: tsan
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -104,13 +104,37 @@
       }
     },
     {
-      "name": "linux-clang-x64-release",
-      "displayName": "Linux Clang x64 Release",
+      "name": "linux-clang-x64-debug",
+      "displayName": "Linux Clang x64 Debug",
       "inherits": "linux-x64-debug",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "clang-19",
         "CMAKE_CXX_COMPILER": "clang++-19"
+      }
+    },
+    {
+      "name": "linux-asan-ubsan",
+      "displayName": "Linux ASAN/UBSAN",
+      "inherits": "linux-clang-x64-debug",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=undefined -fsanitize-trap=all -fno-omit-frame-pointer -O1",
+        "DISABLE_TEST_DISCOVERY": "true"
+      }
+    },
+    {
+      "name": "linux-tsan",
+      "displayName": "Linux TSAN",
+      "inherits": "linux-clang-x64-debug",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer -O2"
+      }
+    },
+    {
+      "name": "linux-clang-x64-release",
+      "displayName": "Linux Clang x64 Release",
+      "inherits": "linux-clang-x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
       }
     }
   ]

--- a/chess-engine-lib/MoveSearcher.cpp
+++ b/chess-engine-lib/MoveSearcher.cpp
@@ -222,8 +222,12 @@ const auto lmrReductionTable = []() {
     for (int depthIdx = 0; depthIdx < (int)table.size(); ++depthIdx) {
         const int depth = depthIdx + 1;
         for (int movesSearched = 0; movesSearched < (int)table[0].size(); ++movesSearched) {
-            table[depthIdx][movesSearched] =
-                    (int)max(0., 0.5 + std::log(depth) * std::log(movesSearched) / 3);
+            if (movesSearched == 0) {
+                table[depthIdx][movesSearched] = 0;
+            } else {
+                table[depthIdx][movesSearched] =
+                        (int)max(0., 0.5 + std::log(depth) * std::log(movesSearched) / 3);
+            }
         }
     }
 

--- a/chess-engine-lib/PieceControl.cpp
+++ b/chess-engine-lib/PieceControl.cpp
@@ -159,10 +159,13 @@ BitBoard computeBishopXRaySquares(const BoardPosition origin, BitBoard anyPiece)
     const int firstSWOccupied = kSquares - 1 - std::countl_zero(southWestOccupancy);
     const int firstNWOccupied = std::countr_zero(northWestOccupancy);
 
-    anyPiece &= ~(BoardPosition)firstNEOccupied;
-    anyPiece &= ~(BoardPosition)firstSEOccupied;
-    anyPiece &= ~(BoardPosition)firstSWOccupied;
-    anyPiece &= ~(BoardPosition)firstNWOccupied;
+    for (const auto& position :
+         {firstNEOccupied, firstSEOccupied, firstSWOccupied, firstNWOccupied}) {
+        if (position < 0 || position >= kSquares) {
+            continue;
+        }
+        anyPiece &= ~(BoardPosition)position;
+    }
 
     const std::uint64_t originBitBoard       = 1ULL << (int)origin;
     const std::uint64_t notBlockingPieceMask = ~((std::uint64_t)anyPiece);
@@ -211,10 +214,13 @@ BitBoard computeRookXRaySquares(const BoardPosition origin, BitBoard anyPiece) {
     const int firstSouthOccupied = kSquares - 1 - std::countl_zero(southOccupancy);
     const int firstWestOccupied  = kSquares - 1 - std::countl_zero(westOccupancy);
 
-    anyPiece &= ~(BoardPosition)firstNorthOccupied;
-    anyPiece &= ~(BoardPosition)firstEastOccupied;
-    anyPiece &= ~(BoardPosition)firstSouthOccupied;
-    anyPiece &= ~(BoardPosition)firstWestOccupied;
+    for (const auto& position :
+         {firstNorthOccupied, firstEastOccupied, firstSouthOccupied, firstWestOccupied}) {
+        if (position < 0 || position >= kSquares) {
+            continue;
+        }
+        anyPiece &= ~(BoardPosition)position;
+    }
 
     const std::uint64_t originBitBoard       = 1ULL << (int)origin;
     const std::uint64_t notBlockingPieceMask = ~((std::uint64_t)anyPiece);

--- a/chess-engine-lib/Pyrrhic/tbprobe.cpp
+++ b/chess-engine-lib/Pyrrhic/tbprobe.cpp
@@ -132,8 +132,17 @@ static uint64_t from_be_u64(uint64_t x) { return bswap64(x); }
 static uint32_t from_be_u32(uint32_t x) { return bswap32(x); }
 #endif
 
-inline static uint32_t read_le_u32(void *p) { return from_le_u32(*(uint32_t *)p); }
-inline static uint16_t read_le_u16(void *p) { return from_le_u16(*(uint16_t *)p); }
+inline static uint32_t read_le_u32(void *p) {
+    uint32_t aligned;
+    memcpy(&aligned, p, sizeof(aligned));
+    return from_le_u32(aligned);
+}
+
+inline static uint16_t read_le_u16(void *p) {
+    uint16_t aligned;
+    memcpy(&aligned, p, sizeof(aligned));
+    return from_le_u16(aligned);
+}
 
 static size_t file_size(FD fd) {
 #ifdef _WIN32

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,4 +29,10 @@ target_link_libraries(tests
     chess-engine-lib-dyn-crt
 )
 
-gtest_discover_tests(tests)
+# We disable test discovery for UBSAN. Since we run UBSAN with -fsanitize-trap=all, the test binary
+# may crash, even when just discovering tests. This causes the build to fail.
+# We don't want the build to fail, just running the tests. So in this scenario we disable test
+# discovery.
+if (NOT DISABLE_TEST_DISCOVERY)
+    gtest_discover_tests(tests)
+endif()


### PR DESCRIPTION
- Add CMake presets for ASAN+UBSAN and for TSAN.
- Fix errors revealed by UBSAN:
  - In calculating LMR table: conversion of NaN (from log(0)) to int.
  - In x-ray attack calculation: bit-shifts by 64 or -1.
  - In Syzygy TB probing: unaligned reads.
- Add CI test runs under these sanitizer modees.