### PR TITLE
Revamp CMake presets.

### DIFF
--- a/.github/workflows/archive-engine.yml
+++ b/.github/workflows/archive-engine.yml
@@ -6,78 +6,76 @@ on:
 
 jobs:
   archive_engine:
-    name: ${{ matrix.os }}, ${{ matrix.config_name }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config.preset }}
+    runs-on: ${{ matrix.config.os }}
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        config_name: [clang-x64-release]
+        config:
+          - {
+              os: windows-latest,
+              preset: windows-clang-cl-release
+            }
+          - {
+              os: ubuntu-latest,
+              preset: linux-clang-release
+            }
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - name: Install required packages
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-14 g++-14 clang-19
-        clang++-19 --version
-        g++-14 --version
+      - name: Install required packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-19
+          clang++-19 --version
 
-    - name: Get CMake
-      uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
+      - name: Get CMake
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
 
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
 
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-        if [[ ${{ matrix.os }} = "windows-latest" ]]; then
-          echo "os-name=windows" >> "$GITHUB_OUTPUT"
-        fi
-        if [[ ${{ matrix.os }} = "ubuntu-latest" ]]; then
-          echo "os-name=linux" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Enable Developer Command Prompt
-      if: matrix.os == 'windows-latest'
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      - name: Enable Developer Command Prompt
+        if: matrix.config.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
-    - name: Configure CMake
-      run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        --preset ${{ steps.strings.outputs.os-name }}-${{ matrix.config_name }}
-        -DTARGETS_TO_BUILD="engine"
+      - name: Configure CMake
+        run: >
+          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          --preset ${{ matrix.config.preset }}
+          -DTARGETS_TO_BUILD="engine"
 
-    - name: Build
-      run: >
-        cmake
-        --build ${{ steps.strings.outputs.build-output-dir }}
-        --target Euwe
+      - name: Build
+        run: >
+          cmake
+          --build ${{ steps.strings.outputs.build-output-dir }}
+          --target Euwe
 
-    - name: Prepare artifact directory
-      if: matrix.config_name == 'clang-x64-release' && github.ref == 'refs/heads/main'
-      working-directory: .
-      run: |
-        mkdir artifacts
-        cp ${{ steps.strings.outputs.build-output-dir }}/chess-engine/Euwe* artifacts
-        cp LICENSE artifacts
-        cp NOTICE artifacts
+      - name: Prepare artifact directory
+        working-directory: .
+        run: |
+          mkdir artifacts
+          cp ${{ steps.strings.outputs.build-output-dir }}/chess-engine/Euwe* artifacts
+          cp LICENSE artifacts
+          cp NOTICE artifacts
 
-    - name: Archive binary
-      if: matrix.config_name == 'clang-x64-release' && github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-      with:
-        name: Euwe-dev.${{ steps.strings.outputs.os-name }}
-        path: |
-          artifacts/LICENSE
-          artifacts/NOTICE
-          artifacts/Euwe*
+      - name: Archive binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: Euwe-dev.${{ steps.strings.outputs.os-name }}
+          path: |
+            artifacts/LICENSE
+            artifacts/NOTICE
+            artifacts/Euwe*

--- a/.github/workflows/build-tuner.yml
+++ b/.github/workflows/build-tuner.yml
@@ -13,67 +13,84 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
 
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
-      with:
-        concurrent_skipping: same_content_newer
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          concurrent_skipping: same_content_newer
 
   build_tuner:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    name: (${{ matrix.os }}, ${{ matrix.config_name }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config.preset }}
+    runs-on: ${{ matrix.config.os }}
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        config_name: [x64-debug, x64-release, clang-x64-release]
+        config:
+          # Windows MSVC
+          - {
+              os: windows-latest,
+              preset: windows-msvc-debug
+            }
+          - {
+              os: windows-latest,
+              preset: windows-msvc-release
+            }
+
+          # Windows clang-cl
+          - {
+              os: windows-latest,
+              preset: windows-clang-cl-release
+            }
+
+          # Linux clang
+          - {
+              os: ubuntu-latest,
+              preset: linux-clang-debug
+            }
+          - {
+              os: ubuntu-latest,
+              preset: linux-clang-release
+            }
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - name: Install required packages
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-14 g++-14 clang-19
-        clang++-19 --version
-        g++-14 --version
+      - name: Install required packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-19
+          clang++-19 --version
 
-    - name: Get CMake
-      uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
+      - name: Get CMake
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
+      
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
 
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-        if [[ ${{ matrix.os }} = "windows-latest" ]]; then
-          echo "os-name=windows" >> "$GITHUB_OUTPUT"
-        fi
-        if [[ ${{ matrix.os }} = "ubuntu-latest" ]]; then
-          echo "os-name=linux" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Enable Developer Command Prompt
+        if: matrix.config.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      
+      - name: Configure CMake
+        run: >
+          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          --preset ${{ matrix.config.preset }}
+          -DTARGETS_TO_BUILD="tuner"
 
-    - name: Enable Developer Command Prompt
-      if: matrix.os == 'windows-latest'
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-
-    - name: Configure CMake
-      run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        --preset ${{ steps.strings.outputs.os-name }}-${{ matrix.config_name }}
-        -DTARGETS_TO_BUILD="tuner"
-
-    - name: Build
-      run: >
-        cmake
-        --build ${{ steps.strings.outputs.build-output-dir }}
-        --target Tuner
+      - name: Build
+        run: >
+          cmake
+          --build ${{ steps.strings.outputs.build-output-dir }}
+          --target Tuner

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,10 +10,10 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
 
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
-      with:
-        concurrent_skipping: same_content_newer
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          concurrent_skipping: same_content_newer
 
   formatting_check:
     needs: pre_job
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-  
-    - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8
-      with:
-        clang-format-version: '19'
-        exclude-regex: '.*/Pyrrhic/.*'
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8
+        with:
+          clang-format-version: '19'
+          exclude-regex: '.*/Pyrrhic/.*'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,77 +10,98 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
 
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
-      with:
-        concurrent_skipping: same_content_newer
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          concurrent_skipping: same_content_newer
 
   build_and_test:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    name: ${{ matrix.os }}, ${{ matrix.config_name }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config.preset }}
+    runs-on: ${{ matrix.config.os }}
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        config_name: [x64-debug, x64-release, clang-x64-release]
+        config:
+          # Windows MSVC
+          - {
+              os: windows-latest,
+              preset: windows-msvc-debug
+            }
+          - {
+              os: windows-latest,
+              preset: windows-msvc-release
+            }
 
-        include:
-        - os: ubuntu-latest
-          config_name: asan-ubsan
-        - os: ubuntu-latest
-          config_name: tsan
+          # Windows clang-cl
+          - {
+              os: windows-latest,
+              preset: windows-clang-cl-release
+            }
+
+          # Linux clang
+          - {
+              os: ubuntu-latest,
+              preset: linux-clang-debug
+            }
+          - {
+              os: ubuntu-latest,
+              preset: linux-clang-release
+            }
+
+          # Linux sanitizers
+          - {
+              os: ubuntu-latest,
+              preset: linux-asan-ubsan
+            }
+          - {
+              os: ubuntu-latest,
+              preset: linux-tsan
+            }
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - name: Install required packages
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-14 g++-14 clang-19
-        clang++-19 --version
-        g++-14 --version
+      - name: Install required packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-19
+          clang++-19 --version
 
-    - name: Get CMake
-      uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
+      - name: Get CMake
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
 
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
 
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-        if [[ ${{ matrix.os }} = "windows-latest" ]]; then
-          echo "os-name=windows" >> "$GITHUB_OUTPUT"
-        fi
-        if [[ ${{ matrix.os }} = "ubuntu-latest" ]]; then
-          echo "os-name=linux" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Enable Developer Command Prompt
-      if: matrix.os == 'windows-latest'
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      - name: Enable Developer Command Prompt
+        if: matrix.config.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
-    - name: Configure CMake
-      run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        --preset ${{ steps.strings.outputs.os-name }}-${{ matrix.config_name }}
-        -DTARGETS_TO_BUILD="tests"
-
-    - name: Build
-      run: >
-        cmake
-        --build ${{ steps.strings.outputs.build-output-dir }}
-        --target tests
-
-    - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      run: tests/tests
+      - name: Configure CMake
+        run: >
+          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          --preset ${{ matrix.config.preset }}
+          -DTARGETS_TO_BUILD="tests"
+   
+      - name: Build
+        run: >
+          cmake
+          --build ${{ steps.strings.outputs.build-output-dir }}
+          --target tests
+   
+      - name: Test
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        run: tests/tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,24 +1,26 @@
 ﻿{
   "version": 3,
   "configurePresets": [
+
     {
       "name": "windows-base",
       "hidden": true,
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "installDir": "${sourceDir}/out/install/${presetName}",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "cl.exe",
-        "CMAKE_CXX_COMPILER": "cl.exe",
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_TARGET_TRIPLET": "x64-windows",
-        "ENABLE_PROFILE_GENERATION": "OFF",
-        "TARGETS_TO_BUILD": "engine;tests;tuner"
-      },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "TARGETS_TO_BUILD": "engine;tests;tuner"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -28,43 +30,24 @@
       }
     },
     {
-      "name": "windows-x64-debug",
-      "displayName": "Windows x64 Debug",
+      "name": "windows-msvc-base",
+      "hidden": true,
       "inherits": "windows-base",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
       }
     },
     {
-      "name": "windows-x64-release-debug",
-      "displayName": "Windows x64 Release w/ Debug info",
-      "inherits": "windows-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "windows-x64-release",
-      "displayName": "Windows x64 Release",
-      "inherits": "windows-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "windows-clang-x64-release",
-      "displayName": "Windows clang x64 Release",
-      "inherits": "windows-x64-debug",
+      "name": "windows-clang-cl-base",
+      "hidden": true,
+      "inherits": "windows-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang-cl.exe",
-        "CMAKE_CXX_COMPILER": "clang-cl.exe",
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
       }
     },
+
     {
       "name": "linux-base",
       "hidden": true,
@@ -76,47 +59,82 @@
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       },
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_C_COMPILER": "gcc-14",
-        "CMAKE_CXX_COMPILER": "g++-14",
-        "TARGETS_TO_BUILD": "engine;tests;tuner"
-      }
-    },
-    {
-      "name": "linux-x64-debug",
-      "displayName": "Linux x64 Debug",
-      "inherits": "linux-base",
       "architecture": {
         "value": "x64",
         "strategy": "external"
       },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "TARGETS_TO_BUILD": "engine;tests;tuner"
       }
     },
     {
-      "name": "linux-x64-release",
-      "displayName": "Linux x64 Release",
-      "inherits": "linux-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "linux-clang-x64-debug",
-      "displayName": "Linux Clang x64 Debug",
-      "inherits": "linux-x64-debug",
+      "name": "linux-clang-base",
+      "hidden": true,
+      "inherits": "linux-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang-19",
         "CMAKE_CXX_COMPILER": "clang++-19"
       }
     },
+
+    {
+      "name": "windows-msvc-debug",
+      "displayName": "Windows MSVC Debug",
+      "inherits": "windows-msvc-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-msvc-release-debug",
+      "displayName": "Windows MSVC Release w/ Debug info",
+      "inherits": "windows-msvc-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "windows-msvc-release",
+      "displayName": "Windows MSVC Release",
+      "inherits": "windows-msvc-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+
+    {
+      "name": "windows-clang-cl-release",
+      "displayName": "Windows clang-cl Release",
+      "inherits": "windows-clang-cl-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+
+    {
+      "name": "linux-clang-debug",
+      "displayName": "Linux clang Debug",
+      "inherits": "linux-clang-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-release",
+      "displayName": "Linux clang Release",
+      "inherits": "linux-clang-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+
     {
       "name": "linux-asan-ubsan",
       "displayName": "Linux ASAN/UBSAN",
-      "inherits": "linux-clang-x64-debug",
+      "inherits": "linux-clang-base",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=undefined -fsanitize-trap=all -fno-omit-frame-pointer -O1",
         "DISABLE_TEST_DISCOVERY": "true"
       }
@@ -124,17 +142,10 @@
     {
       "name": "linux-tsan",
       "displayName": "Linux TSAN",
-      "inherits": "linux-clang-x64-debug",
+      "inherits": "linux-clang-base",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer -O2"
-      }
-    },
-    {
-      "name": "linux-clang-x64-release",
-      "displayName": "Linux Clang x64 Release",
-      "inherits": "linux-clang-x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -219,14 +219,14 @@ want to build the engine, modify `TARGETS_TO_BUILD` in the CMakePresets.json fil
    file to point to your VCPKG installation directly).
  - If needed, modify CMakePresets.json to match your build environment.
  - Run `cmake` with appropriate options. E.g., run
-   `cmake --preset linux-x64-release -DTARGETS_TO_BUILD="engine"` to build in release mode.
- - Run `cmake --build` on the output directory. E.g., `cmake --build out/build/linux-x64-release/`.
+   `cmake --preset linux-clang-release -DTARGETS_TO_BUILD="engine"` to build in release mode.
+ - Run `cmake --build` on the output directory. E.g., `cmake --build out/build/linux-clang-release/`.
 
-The project has been tested with g++ 14.2, and clang 19 and 20.
+The project is tested in CI with clang 19, but should also work with clang 20 and gcc 14.
 
 The above instructions will only compile the engine. To also compile the tests and/or the tuner, add
 the appropriate target to the `TARGETS_TO_BUILD` option. So to configure for building all 3 targets,
-run: `cmake --preset linux-x64-release -DTARGETS_TO_BUILD="engine;tests;tuner"`. This will trigger
+run: `cmake --preset linux-clang-release -DTARGETS_TO_BUILD="engine;tests;tuner"`. This will trigger
 installation of the required dependencies using vcpkg.
 
 If `TARGETS_TO_BUILD` is not set, the default is to build all targets.


### PR DESCRIPTION
 - Make CMakePresets.json more organized.
 - Remove presets using system-default compiler (gcc) on Linux. Now all Linux presets use clang.
 - Use explicit configs instead of cartesian product matrix in CI workflows.