### PR TITLE
Use run-cmake action instead of invoking cmake directly

### DIFF
--- a/.github/workflows/archive-engine.yml
+++ b/.github/workflows/archive-engine.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
 
-      - name: Run CMake
+      - name: CMake configure & build
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: ${{ matrix.config.preset }}

--- a/.github/workflows/archive-engine.yml
+++ b/.github/workflows/archive-engine.yml
@@ -50,29 +50,21 @@ jobs:
         id: strings
         shell: bash
         run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+          echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
 
-      - name: Enable Developer Command Prompt
-        if: matrix.config.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-
-      - name: Configure CMake
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          --preset ${{ matrix.config.preset }}
-          -DTARGETS_TO_BUILD="engine"
-
-      - name: Build
-        run: >
-          cmake
-          --build ${{ steps.strings.outputs.build-output-dir }}
-          --target Euwe
+      - name: Run CMake
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
+        with:
+          configurePreset: ${{ matrix.config.preset }}
+          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=engine']"
+          buildPreset: ${{ matrix.config.preset }}
+          buildPresetAdditionalArgs: "['--target', 'Euwe']"
 
       - name: Prepare artifact directory
         working-directory: .
         run: |
           mkdir artifacts
-          cp ${{ steps.strings.outputs.build-output-dir }}/src/chess-engine/Euwe* artifacts
+          cp ${{ steps.strings.outputs.build-output-dir }}/chess-engine/Euwe* artifacts
           cp LICENSE artifacts
           cp NOTICE artifacts
 

--- a/.github/workflows/build-tuner.yml
+++ b/.github/workflows/build-tuner.yml
@@ -77,20 +77,12 @@ jobs:
         id: strings
         shell: bash
         run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+          echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
 
-      - name: Enable Developer Command Prompt
-        if: matrix.config.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-      
-      - name: Configure CMake
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          --preset ${{ matrix.config.preset }}
-          -DTARGETS_TO_BUILD="tuner"
-
-      - name: Build
-        run: >
-          cmake
-          --build ${{ steps.strings.outputs.build-output-dir }}
-          --target Tuner
+      - name: Run CMake
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
+        with:
+          configurePreset: ${{ matrix.config.preset }}
+          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=tuner']"
+          buildPreset: ${{ matrix.config.preset }}
+          buildPresetAdditionalArgs: "['--target', 'Tuner']"

--- a/.github/workflows/build-tuner.yml
+++ b/.github/workflows/build-tuner.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
 
-      - name: Run CMake
+      - name: CMake configure & build
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: ${{ matrix.config.preset }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
 
-      - name: Run CMake
+      - name: CMake configure
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: linux-clang-debug

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
 
-      - name: Configure CMake
-        run: >
-          cmake --preset linux-clang-debug
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Run CMake
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
+        with:
+          configurePreset: linux-clang-debug
+          configurePresetAdditionalArgs: "['-DCMAKE_EXPORT_COMPILE_COMMANDS=ON']"
 
       - name: Run clang-tidy script
         run: |

--- a/.github/workflows/e2e-engine-tests.yml
+++ b/.github/workflows/e2e-engine-tests.yml
@@ -87,7 +87,7 @@ jobs:
         id: strings
         shell: bash
         run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+          echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
           if [[ ${{ matrix.config.os }} = "windows-latest" ]]; then
             echo "syzygy-paths=\"./3-4-5-wdl;./3-4-5-dtz\"" >> "$GITHUB_OUTPUT"
           fi
@@ -111,21 +111,13 @@ jobs:
         run: |
           bash build-msan-libcxx.sh
 
-      - name: Enable Developer Command Prompt
-        if: matrix.config.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-
-      - name: Configure CMake
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          --preset ${{ matrix.config.preset }}
-          -DTARGETS_TO_BUILD="engine"
-
-      - name: Build
-        run: >
-          cmake
-          --build ${{ steps.strings.outputs.build-output-dir }}
-          --target Euwe
+      - name: Run CMake
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
+        with:
+          configurePreset: ${{ matrix.config.preset }}
+          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=engine']"
+          buildPreset: ${{ matrix.config.preset }}
+          buildPresetAdditionalArgs: "['--target', 'Euwe']"
 
       - name: Get fastchess (Linux)
         if: matrix.config.os == 'ubuntu-latest'
@@ -185,8 +177,8 @@ jobs:
       - name: Run tournament
         run: >
           ./fastchess
-          -engine cmd=${{ steps.strings.outputs.build-output-dir }}/src/chess-engine/Euwe name=Euwe1
-          -engine cmd=${{ steps.strings.outputs.build-output-dir }}/src/chess-engine/Euwe name=Euwe2
+          -engine cmd=${{ steps.strings.outputs.build-output-dir }}/chess-engine/Euwe name=Euwe1
+          -engine cmd=${{ steps.strings.outputs.build-output-dir }}/chess-engine/Euwe name=Euwe2
           -each tc="inf/1+0.01" option.Hash=64 option.SyzygyPath=${{ steps.strings.outputs.syzygy-paths }}
           -openings file=UHO_4060_v2.epd format=epd order=sequential
           -rounds 50

--- a/.github/workflows/e2e-engine-tests.yml
+++ b/.github/workflows/e2e-engine-tests.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           bash build-msan-libcxx.sh
 
-      - name: Run CMake
+      - name: CMake configure & build
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: ${{ matrix.config.preset }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           bash build-msan-libcxx.sh
 
-      - name: Run CMake
+      - name: CMake configure & build
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: ${{ matrix.config.preset }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -115,7 +115,7 @@ jobs:
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         with:
           configurePreset: ${{ matrix.config.preset }}
-          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=\"tests\"']"
+          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=tests']"
           buildPreset: ${{ matrix.config.preset }}
           buildPresetAdditionalArgs: "['--target', 'tests']"
    

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,7 @@ jobs:
         id: strings
         shell: bash
         run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+          echo "build-output-dir=${{ github.workspace }}/out/build/${{ matrix.config.preset }}/src" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached MSan libc++
         if: matrix.config.preset == 'linux-msan'
@@ -111,24 +111,16 @@ jobs:
         run: |
           bash build-msan-libcxx.sh
 
-      - name: Enable Developer Command Prompt
-        if: matrix.config.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-
-      - name: Configure CMake
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          --preset ${{ matrix.config.preset }}
-          -DTARGETS_TO_BUILD="tests"
-   
-      - name: Build
-        run: >
-          cmake
-          --build ${{ steps.strings.outputs.build-output-dir }}
-          --target tests
+      - name: Run CMake
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
+        with:
+          configurePreset: ${{ matrix.config.preset }}
+          configurePresetAdditionalArgs: "['-DTARGETS_TO_BUILD=\"tests\"']"
+          buildPreset: ${{ matrix.config.preset }}
+          buildPresetAdditionalArgs: "['--target', 'tests']"
    
       - name: Run tests
-        working-directory: ${{ steps.strings.outputs.build-output-dir }}/src
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
         run: tests/tests
 
       - name: Install Valgrind
@@ -139,6 +131,6 @@ jobs:
 
       - name: Run tests under Valgrind
         if: matrix.config.preset == 'linux-clang-debug'
-        working-directory: ${{ steps.strings.outputs.build-output-dir }}/src
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
         run: |
           valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=1 tests/tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,6 @@
 ﻿{
   "version": 3,
+
   "configurePresets": [
 
     {
@@ -162,6 +163,48 @@
         "VCPKG_TARGET_TRIPLET": "x64-linux-msan",
         "TARGETS_TO_BUILD": "engine;tests"
       }
+    }
+  ],
+
+  "buildPresets": [
+    {
+      "name": "windows-msvc-debug",
+      "configurePreset": "windows-msvc-debug"
+    },
+    {
+      "name": "windows-msvc-release-debug",
+      "configurePreset": "windows-msvc-release-debug"
+    },
+    {
+      "name": "windows-msvc-release",
+      "configurePreset": "windows-msvc-release"
+    },
+
+    {
+      "name": "windows-clang-cl-release",
+      "configurePreset": "windows-clang-cl-release"
+    },
+
+    {
+      "name": "linux-clang-debug",
+      "configurePreset": "linux-clang-debug"
+    },
+    {
+      "name": "linux-clang-release",
+      "configurePreset": "linux-clang-release"
+    },
+
+    {
+      "name": "linux-asan-ubsan",
+      "configurePreset": "linux-asan-ubsan"
+    },
+    {
+      "name": "linux-tsan",
+      "configurePreset": "linux-tsan"
+    },
+    {
+      "name": "linux-msan",
+      "configurePreset": "linux-msan"
     }
   ]
 }


### PR DESCRIPTION
Hopefully (?) this will improve the vcpkg caching behavior.

Additionally, can now use `cmake --build --preset` instead of `cmake --build <dir>`.