### PR TITLE
Offset bound used for null-move-pruning.

### DIFF
--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -800,12 +800,16 @@ EvalT MoveSearcher::Impl::search(
 
         const auto unmakeInfo = gameState.makeNullMove();
 
+        static constexpr EvalT kNullMoveBoundOffset = -14;
+
+        const EvalT nullMoveBound = beta + kNullMoveBoundOffset;
+
         EvalT nullMoveScore =
                 -search(gameState,
                         nullMoveSearchDepth,
                         ply + 1,
-                        -beta,
-                        -beta + 1,
+                        -nullMoveBound,
+                        -nullMoveBound + 1,
                         /*lastMove =*/{},
                         /*lastNullMovePly =*/ply,
                         stack);
@@ -818,11 +822,11 @@ EvalT MoveSearcher::Impl::search(
             return -kInfiniteEval;
         }
 
-        if (nullMoveScore >= beta) {
+        if (nullMoveScore >= nullMoveBound) {
             storeNullMoveScoreInTTable(beta, depth, gameState.getBoardHash());
 
             // Null move failed high, don't bother searching other moves.
-            // Return a conservative lower bound (fail-hard).
+            // We don't have a good bound, so just return beta.
             return beta;
         }
     }

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "tuned-9M-LBFGS");
+            UciFrontEnd uciFrontEnd(engine, "null-move-bound-offset");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
The offset of -14 makes NMP more aggressive.

```
--------------------------------------------------
Results of null-move-bound-offset vs tuned-9M-LBFGS (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: 16.41 +/- 10.65, nElo: 24.35 +/- 15.77
LOS: 99.88 %, DrawRatio: 41.52 %, PairsRatio: 1.34
Games: 1864, Wins: 566, Losses: 478, Draws: 820, Points: 976.0 (52.36 %)
Ptnml(0-2): [47, 186, 387, 256, 56], WL/DD Ratio: 1.05
LLR: 2.96 (100.4%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
Finished match
```