### PR TITLE
Immediate stop bugfix

### DIFF
--- a/src/chess-engine-lib/Engine.cpp
+++ b/src/chess-engine-lib/Engine.cpp
@@ -77,14 +77,7 @@ void Engine::Impl::newGame() {
 
 SearchInfo Engine::Impl::findMove(
         const GameState& gameState, const std::vector<Move>& searchMoves) {
-    int maxDepth = MoveSearcher::kMaxDepth;
-
-    auto allLegalMoves = gameState.generateMoves(moveStack_);
-    if (allLegalMoves.size() == 1) {
-        // Only one legal move. We still search to get a score and a PV.
-        // Search to depth 2 to get a guess for the opponent's follow-up move.
-        maxDepth = 2;
-    }
+    const auto allLegalMoves = gameState.generateMoves(moveStack_);
 
     for (const auto& move : searchMoves) {
         bool isLegal = false;
@@ -131,13 +124,8 @@ SearchInfo Engine::Impl::findMove(
                                                  : !syzygyRootMoves.empty()   ? &syzygyRootMoves
                                                                               : nullptr;
 
-    if (movesToSearch && movesToSearch->size() == 1 && searchMoves.size() != 1) {
-        // Only one move to search. We still search to get a score and a PV.
-        // Search to depth 2 to get a guess for the opponent's follow-up move.
-        // Don't do this if searchMoves.size() == 1, because that means the user explicitly
-        // requested this move to be searched.
-        maxDepth = 2;
-    }
+    const int numMovesToConsider =
+            movesToSearch ? (int)movesToSearch->size() : (int)allLegalMoves.size();
 
     moveSearcher_.resetSearchStatistics();
     moveSearcher_.prepareForNewSearch(gameState, movesToSearch, tbHit);
@@ -153,8 +141,6 @@ SearchInfo Engine::Impl::findMove(
     if (rootNodeInfo) {
         depth     = max(depth, rootNodeInfo->depth);
         evalGuess = rootNodeInfo->eval;
-
-        maxDepth = max(maxDepth, depth);
     }
 
     if (frontEnd_) {
@@ -163,7 +149,7 @@ SearchInfo Engine::Impl::findMove(
         frontEnd_->reportSearchHasStarted();
     }
 
-    for (; depth <= maxDepth; ++depth) {
+    for (; depth <= MoveSearcher::kMaxDepth; ++depth) {
         // Not const to enable std::move of the PV.
         auto searchResult =
                 moveSearcher_.searchForBestMove(copyState, depth, moveStack_, evalGuess);
@@ -196,7 +182,7 @@ SearchInfo Engine::Impl::findMove(
             break;
         }
 
-        if (timeManager_.shouldStopAfterFullPly(depth)) {
+        if (timeManager_.shouldStopAfterFullPly(depth, numMovesToConsider)) {
             break;
         }
     }

--- a/src/chess-engine-lib/Engine.cpp
+++ b/src/chess-engine-lib/Engine.cpp
@@ -157,6 +157,12 @@ SearchInfo Engine::Impl::findMove(
         maxDepth = max(maxDepth, depth);
     }
 
+    if (frontEnd_) {
+        // Preparations are done; we can now safely process an interrupt request.
+        // Report to the front end that the search has started.
+        frontEnd_->reportSearchHasStarted();
+    }
+
     for (; depth <= maxDepth; ++depth) {
         // Not const to enable std::move of the PV.
         auto searchResult =

--- a/src/chess-engine-lib/IFrontEnd.h
+++ b/src/chess-engine-lib/IFrontEnd.h
@@ -15,6 +15,10 @@ class IFrontEnd {
     // Run in a loop, handling commands and sending them to the engine.
     virtual void run() = 0;
 
+    // Used by the engine to report to the front end that the search has started and that
+    // further commands can now be processed.
+    virtual void reportSearchHasStarted() = 0;
+
     // Can be used by the engine to report that a search to a certain depth has been fully
     // completed.
     virtual void reportFullSearch(const SearchInfo& searchInfo) const = 0;

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -1547,6 +1547,7 @@ void MoveSearcher::Impl::prepareForNewSearch(
         const std::vector<Move>* const movesToSearch,
         const bool tbHitAtRoot) {
     // Set state variables to prepare for search.
+    stopSearch_     = false;
     wasInterrupted_ = false;
 
     moveScorer_.prepareForNewSearch(gameState);

--- a/src/chess-engine-lib/TimeManager.cpp
+++ b/src/chess-engine-lib/TimeManager.cpp
@@ -67,11 +67,14 @@ bool TimeManager::shouldInterruptSearch(const std::uint64_t nodesSearched) const
     }
 }
 
-bool TimeManager::shouldStopAfterFullPly(const int depth) const {
+bool TimeManager::shouldStopAfterFullPly(const int depth, const int numMovesToConsider) const {
     MY_ASSERT(mode_ != TimeManagementMode::None);
 
     switch (mode_) {
         case TimeManagementMode::TimeControl: {
+            if (numMovesToConsider == 1) {
+                return depth >= 2;
+            }
             return timeIsUp(softDeadLine_);
         }
 

--- a/src/chess-engine-lib/TimeManager.h
+++ b/src/chess-engine-lib/TimeManager.h
@@ -15,7 +15,7 @@ class TimeManager {
 
     [[nodiscard]] bool shouldInterruptSearch(std::uint64_t nodesSearched) const;
 
-    [[nodiscard]] bool shouldStopAfterFullPly(int depth) const;
+    [[nodiscard]] bool shouldStopAfterFullPly(int depth, int numMovesToConsider) const;
 
     void forceNextCheck() const;
 

--- a/src/chess-engine-lib/UciFrontEnd.h
+++ b/src/chess-engine-lib/UciFrontEnd.h
@@ -29,6 +29,8 @@ class UciFrontEnd final : public IFrontEnd {
 
     void run() override;
 
+    void reportSearchHasStarted() override;
+
     void reportFullSearch(const SearchInfo& searchInfo) const override;
 
     void reportPartialSearch(const SearchInfo& searchInfo) const override;


### PR DESCRIPTION
* Fix bug where engine instantly stops search

The engine could get in a state where a stop command issued before the
go command would cause the engine to immediately stop the search. In an
analysis loop this bad state would then persist, as the subsequent stop
would cause the next go to immediately stop as well.

Previously, the searcher had been modified to not clear the stop flag at
the start of the search, to avoid a race between clearing the stop flag
and setting the stop flag if the uci input has go immediately followed
by stop.

But if the search has already stopped on its own but the go future has
not yet been consumed, the stop flag would be set when a stop command is
issued. This stop flag then wouldn't be 'consumed' until the next go
command, leading to the above scenario.

A particular scenario where this could happen during analysis is:
 - Position with only one legal move.
 - UCI: go infinite.
 - Engine stops search almost immediately on its own.
 - Go future is not consumed yet.
 - UCI: stop.
 - Stop flag is set and go future is consumed.
 - Now the next go command will immediately stop.

Here is a repro:
```
uci
position fen 1k6/6p1/8/8/8/8/1q6/1K6 w - - 0 1
go infinite
(wait until search stops)
stop
position moves b1b2
go infinite
(this stops immediately, though it shouldn't)
stop
position moves b8c7
go infinite
(also stops immediately)
(engine crashes: no PV could be found in hash table, so no PV in search,
so no bestmove)
```

To fix this, we always clear the stop flag at the start of the search. To avoid the race with an immediate stop command, we block the front end from processing additional commands until `Engine` reports that the search has started (at which point the stop flag has been cleared).

* Move responsibility for early search stop to time manager.

Also only do the early stop when under time control, not in analysis
mode.