### PR TITLE
Switch to DTZ-optimal play after 1st repetition.

### DIFF
--- a/src/chess-engine-lib/GameState.cpp
+++ b/src/chess-engine-lib/GameState.cpp
@@ -1105,6 +1105,20 @@ bool GameState::isRepetition(const int repetitionThreshold) const {
     return false;
 }
 
+bool GameState::hasRepeated() const {
+    // Ok to use a quadratic search here, because we only call it at the root for EGTB probing.
+    for (int hashIdx1 = lastReversiblePositionHashIdx_; hashIdx1 < (int)previousHashes_.size() - 1;
+         ++hashIdx1) {
+        // Increment by 2 to only compare positions with the same side to move.
+        for (int hashIdx2 = hashIdx1 + 2; hashIdx2 < (int)previousHashes_.size(); hashIdx2 += 2) {
+            if (previousHashes_[hashIdx1] == previousHashes_[hashIdx2]) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool GameState::isFiftyMoves() const {
     // 50 move rule
     if (plySinceCaptureOrPawn_ >= 100) {

--- a/src/chess-engine-lib/GameState.h
+++ b/src/chess-engine-lib/GameState.h
@@ -80,6 +80,11 @@ class GameState {
     [[nodiscard]] bool isRepetition(int repetitionThreshold = 3) const;
     [[nodiscard]] bool isFiftyMoves() const;
 
+    // Returns true if any repetition has occurred since the last irreversible move (not necessarily
+    // the current position).
+    // Note: not very fast, should not be called from hot path.
+    [[nodiscard]] bool hasRepeated() const;
+
     [[nodiscard]] bool givesCheck(
             const Move& move,
             const std::array<BitBoard, kNumPieceTypes - 1>& directCheckBitBoards,

--- a/src/chess-engine-lib/Syzygy.cpp
+++ b/src/chess-engine-lib/Syzygy.cpp
@@ -92,7 +92,7 @@ std::vector<Move> getSyzygyRootMoves(const GameState& gameState) {
             gameState.getPlySinceCaptureOrPawn(),
             getSyzygyEnPassantTarget(gameState),
             getSyzygySide(gameState),
-            gameState.isRepetition(2),
+            gameState.hasRepeated(),
             &tbRootMoves);
 
     if (probeResult == 0 || tbRootMoves.size == 0) {

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "knight-outpost-rank3-6");
+            UciFrontEnd uciFrontEnd(engine, "syzygy-has-repeated");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {

--- a/src/tests/GameStateTests.cpp
+++ b/src/tests/GameStateTests.cpp
@@ -11,41 +11,50 @@ TEST(GameStateTests, ThreeFoldRepetition) {
     GameState gameState = GameState::fromFen(fischerPetrosianFen);
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_FALSE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Qe5", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_FALSE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Qh5", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_FALSE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Qf6", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_FALSE(gameState.hasRepeated());
 
     // First repetition
     gameState.makeMove(Move::fromAlgebraic("Qe2", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     // Repetition occurred 4 plies ago
     EXPECT_TRUE(gameState.isRepetition(2));
+    EXPECT_TRUE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Re5", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_TRUE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Qd3", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_TRUE(gameState.hasRepeated());
 
     gameState.makeMove(Move::fromAlgebraic("Rd5", gameState));
     EXPECT_FALSE(gameState.isRepetition());
     EXPECT_FALSE(gameState.isRepetition(2));
+    EXPECT_TRUE(gameState.hasRepeated());
 
     // Second repetition
     gameState.makeMove(Move::fromAlgebraic("Qe2", gameState));
     EXPECT_TRUE(gameState.isRepetition());
     EXPECT_TRUE(gameState.isRepetition(2));
+    EXPECT_TRUE(gameState.hasRepeated());
 }
 
 }  // namespace GameStateTests


### PR DESCRIPTION
Change Syzygy root filtering to apply the 'hasRepeated' condition if there have been any repetitions since the last irreversible move. This is in contrast to the current behavior of only setting that condition if the *current* position has occurred before.

This should cause the engine to switch to DTZ-optimal play if it is in a position that is won according to the EGTB, but where a repetition has occurred in play (showing that it is not making progress). This should prevent situations where a won position results in a draw due to 3-fold repetition. This occurred in tournament play (CCRL), see lichess analysis here: https://lichess.org/9PbxaQ31#135

Tests show no measurable difference in playing strengths under normal conditions.

A test where many games were run starting from the position in the linked game after reaching a 6-piece position (i.e., after `68. Kxc5`) show that it's able to win a very small number of pairs against the old version, which blundered a few draws:
```
--------------------------------------------------
Results of syzygy-has-repeated vs knight-outpost-rank3-6 (3+0.1, NULL, 512MB, Euwe-Clockwork-up-to-egtb.pgn):
Elo: 1.39 +/- 1.36, nElo: 22.06 +/- 21.53
LOS: 97.77 %, DrawRatio: 99.20 %, PairsRatio: inf
Games: 1000, Wins: 500, Losses: 496, Draws: 4, Points: 502.0 (50.20 %)
Ptnml(0-2): [0, 0, 496, 4, 0], WL/DD Ratio: inf
--------------------------------------------------
Finished match
```