### PR TITLE
Aspiration search improvements

### DIFF
--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -1372,7 +1372,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
         const int depth,
         StackOfVectors<Move>& stack,
         const EvalT initialGuess) {
-    static constexpr EvalT kInitialTolerance      = 25;
+    static constexpr EvalT kInitialTolerance      = 10;
     static constexpr int kToleranceIncreaseFactor = 4;
 
     int lowerTolerance = kInitialTolerance;

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -19,7 +19,7 @@
 
 class MoveSearcher::Impl {
   public:
-    Impl(const TimeManager& timeManager, const Evaluator& evaluator);
+    Impl(TimeManager& timeManager, const Evaluator& evaluator);
 
     void setFrontEnd(IFrontEnd* frontEnd);
 
@@ -167,7 +167,7 @@ class MoveSearcher::Impl {
 
     IFrontEnd* frontEnd_ = nullptr;
 
-    const TimeManager& timeManager_;
+    TimeManager& timeManager_;
 
     const Evaluator& evaluator_;
 };
@@ -379,7 +379,7 @@ calculateFutilityMargin(const int reducedDepth, const int movesSearched, const b
 
 }  // namespace
 
-MoveSearcher::Impl::Impl(const TimeManager& timeManager, const Evaluator& evaluator)
+MoveSearcher::Impl::Impl(TimeManager& timeManager, const Evaluator& evaluator)
     : moveScorer_(evaluator), timeManager_(timeManager), evaluator_(evaluator) {
     setTTableSize(getDefaultTTableSizeInMb());
 }
@@ -563,8 +563,8 @@ std::vector<Move> MoveSearcher::Impl::extractPv(
 FORCE_INLINE bool MoveSearcher::Impl::shouldStopSearch() const {
     const std::uint64_t numNodes =
             searchStatistics_.normalNodesSearched + searchStatistics_.qNodesSearched;
-    wasInterrupted_ = wasInterrupted_ || stopSearch_.exchange(false)
-                   || timeManager_.shouldInterruptSearch(numNodes);
+    wasInterrupted_ =
+            wasInterrupted_ || stopSearch_ || timeManager_.shouldInterruptSearch(numNodes);
     return wasInterrupted_;
 }
 
@@ -1409,9 +1409,22 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
 
         if (wasInterrupted_) {
             if (everFailedLow) {
-                // Don't trust the best move if we ever failed low and didn't complete the search.
-                // TODO: we should probably ask for more search time here.
+                // We ran out of time after failing low. This may indicate that our so-far best move
+                // is significantly worse than expected, while at the same time we don't have a
+                // viable move from the deeper search. We should ask for additional time to try to
+                // complete the deeper search.
+                if (!stopSearch_ && timeManager_.requestAdditionalTime()) {
+                    wasInterrupted_ = false;
 
+                    if (frontEnd_) {
+                        frontEnd_->reportDebugString(
+                                "continuing search with additional time after failing low");
+                    }
+
+                    continue;
+                }
+
+                // Don't trust the best move if we ever failed low and didn't complete the search.
                 if (frontEnd_) {
                     frontEnd_->reportDiscardedPv("partial aspiration search with failed low");
                 }
@@ -1641,7 +1654,7 @@ std::optional<RootNodeInfo> MoveSearcher::Impl::getRootNodeInfo(const GameState&
 
 // Implementation of interface: forward to implementation
 
-MoveSearcher::MoveSearcher(const TimeManager& timeManager, const Evaluator& evaluator)
+MoveSearcher::MoveSearcher(TimeManager& timeManager, const Evaluator& evaluator)
     : impl_(std::make_unique<MoveSearcher::Impl>(timeManager, evaluator)) {}
 
 MoveSearcher::~MoveSearcher() = default;

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -1385,8 +1385,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
     EvalT lowerBound = toEval(initialGuess - lowerTolerance);
     EvalT upperBound = toEval(initialGuess + upperTolerance);
 
-    bool everFailedLow  = false;
-    bool everFailedHigh = false;
+    bool everFailedLow = false;
 
     EvalT lastCompletedEval = -kInfiniteEval;
 
@@ -1406,7 +1405,6 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
             lastCompletedEval = searchEval;
 
             everFailedLow |= searchEval <= lowerBound;
-            everFailedHigh |= searchEval >= upperBound;
         }
 
         if (wasInterrupted_) {
@@ -1456,10 +1454,6 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
                 // whichever is lower.
                 lowerBound = toEval(min(searchEval - oldTolerance, initialGuess - lowerTolerance));
             }
-
-            if (!everFailedHigh) {
-                upperBound = toEval(searchEval + 1);
-            }
         } else {
             // Failed high
             if (isMate(searchEval) && searchEval > 0) {
@@ -1473,10 +1467,6 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
                 // Expand the upper bound based on the increased tolerance or the search result,
                 // whichever is higher.
                 upperBound = toEval(max(searchEval + oldTolerance, initialGuess + upperTolerance));
-            }
-
-            if (!everFailedLow) {
-                lowerBound = toEval(searchEval - 1);
             }
         }
 

--- a/src/chess-engine-lib/MoveSearcher.h
+++ b/src/chess-engine-lib/MoveSearcher.h
@@ -26,7 +26,7 @@ class MoveSearcher {
   public:
     static constexpr int kMaxDepth = 100;
 
-    MoveSearcher(const TimeManager& timeManager, const Evaluator& evaluator);
+    MoveSearcher(TimeManager& timeManager, const Evaluator& evaluator);
     ~MoveSearcher();
 
     MoveSearcher(const MoveSearcher&)            = delete;

--- a/src/chess-engine-lib/TimeManager.cpp
+++ b/src/chess-engine-lib/TimeManager.cpp
@@ -42,7 +42,7 @@ bool TimeManager::shouldInterruptSearch(const std::uint64_t nodesSearched) const
 
     switch (mode_) {
         case TimeManagementMode::TimeControl: {
-            return shouldInterrupt(hardDeadLine_, interruptCheckCounter_);
+            return shouldInterrupt(interruptDeadLine_, interruptCheckCounter_);
         }
 
         case TimeManagementMode::Infinite: {
@@ -50,7 +50,7 @@ bool TimeManager::shouldInterruptSearch(const std::uint64_t nodesSearched) const
         }
 
         case TimeManagementMode::FixedTime: {
-            return shouldInterrupt(hardDeadLine_, interruptCheckCounter_);
+            return shouldInterrupt(interruptDeadLine_, interruptCheckCounter_);
         }
 
         case TimeManagementMode::FixedDepth: {
@@ -75,7 +75,7 @@ bool TimeManager::shouldStopAfterFullPly(const int depth, const int numMovesToCo
             if (numMovesToConsider == 1) {
                 return depth >= 2;
             }
-            return timeIsUp(softDeadLine_);
+            return timeIsUp(plyDeadLine_);
         }
 
         case TimeManagementMode::Infinite: {
@@ -83,7 +83,7 @@ bool TimeManager::shouldStopAfterFullPly(const int depth, const int numMovesToCo
         }
 
         case TimeManagementMode::FixedTime: {
-            return timeIsUp(softDeadLine_);
+            return timeIsUp(plyDeadLine_);
         }
 
         case TimeManagementMode::FixedDepth: {
@@ -135,19 +135,22 @@ void TimeManager::configureForTimeControl(
     const std::chrono::milliseconds maxTime    = timeLeft * 8 / 10 - moveOverhead_;
     const std::chrono::milliseconds timeTarget = totalTime / expectedMovesToGo - moveOverhead_;
 
-    const std::chrono::milliseconds hardTimeBudget = std::min(maxTime, timeTarget * 4 / 3);
-    const std::chrono::milliseconds softTimeBudget = hardTimeBudget / 2;
+    const std::chrono::milliseconds extendedTimeBudget = std::min(maxTime, timeTarget * 3);
+    const std::chrono::milliseconds hardTimeBudget     = std::min(maxTime, timeTarget * 4 / 3);
+    const std::chrono::milliseconds softTimeBudget     = hardTimeBudget / 2;
 
     if (frontEnd_) {
         frontEnd_->reportDebugString(std::format(
-                "Time budget: soft {} ms / hard {} ms",
+                "Time budget: soft {} ms / hard {} ms / extended {} ms",
                 softTimeBudget.count(),
-                hardTimeBudget.count()));
+                hardTimeBudget.count(),
+                extendedTimeBudget.count()));
     }
 
-    mode_         = TimeManagementMode::TimeControl;
-    softDeadLine_ = startTime_ + softTimeBudget;
-    hardDeadLine_ = startTime_ + hardTimeBudget;
+    mode_              = TimeManagementMode::TimeControl;
+    plyDeadLine_       = startTime_ + softTimeBudget;
+    interruptDeadLine_ = startTime_ + hardTimeBudget;
+    extendedDeadLine_  = startTime_ + extendedTimeBudget;
 }
 
 void TimeManager::configureForInfiniteSearch() {
@@ -160,9 +163,10 @@ void TimeManager::configureForFixedTimeSearch(const std::chrono::milliseconds ti
     startNewSession();
 
     // In fixed time mode we ignore moveOverhead_.
-    mode_         = TimeManagementMode::FixedTime;
-    softDeadLine_ = startTime_ + time;
-    hardDeadLine_ = softDeadLine_;
+    mode_              = TimeManagementMode::FixedTime;
+    plyDeadLine_       = startTime_ + time;
+    interruptDeadLine_ = plyDeadLine_;
+    extendedDeadLine_  = plyDeadLine_;
 }
 
 void TimeManager::configureForFixedDepthSearch(const int depth) {
@@ -177,6 +181,17 @@ void TimeManager::configureForFixedNodesSearch(const std::uint64_t nodes) {
 
     mode_        = TimeManagementMode::FixedNodes;
     nodesTarget_ = nodes;
+}
+
+bool TimeManager::requestAdditionalTime() {
+    if (mode_ != TimeManagementMode::TimeControl) {
+        return false;
+    }
+
+    interruptDeadLine_ = extendedDeadLine_;
+
+    interruptCheckCounter_ = kInterruptCheckInterval;
+    return !timeIsUp(extendedDeadLine_);
 }
 
 std::chrono::milliseconds TimeManager::getTimeElapsed() const {

--- a/src/chess-engine-lib/TimeManager.h
+++ b/src/chess-engine-lib/TimeManager.h
@@ -37,6 +37,8 @@ class TimeManager {
 
     void configureForFixedNodesSearch(std::uint64_t nodes);
 
+    bool requestAdditionalTime();
+
     [[nodiscard]] std::chrono::milliseconds getTimeElapsed() const;
 
   private:
@@ -55,8 +57,9 @@ class TimeManager {
 
     std::chrono::high_resolution_clock::time_point startTime_{};
 
-    std::chrono::high_resolution_clock::time_point softDeadLine_{};
-    std::chrono::high_resolution_clock::time_point hardDeadLine_{};
+    std::chrono::high_resolution_clock::time_point plyDeadLine_{};
+    std::chrono::high_resolution_clock::time_point interruptDeadLine_{};
+    std::chrono::high_resolution_clock::time_point extendedDeadLine_{};
     int depthTarget_{};
     std::uint64_t nodesTarget_{};
 

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "extra-time-if-fail-low");
+            UciFrontEnd uciFrontEnd(engine, "tight-aspiration-window");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "aspiration-dont-shrink-other-bound");
+            UciFrontEnd uciFrontEnd(engine, "extra-time-if-fail-low");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "syzygy-has-repeated");
+            UciFrontEnd uciFrontEnd(engine, "aspiration-dont-shrink-other-bound");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
 - Do not tighten non-failing bound (passed non-regression SPRT w/ +2 elo)
 - Request additional time if the search is interrupted and we've failed low (SPRT passed w/ +11 elo)
 - Tighten initial aspiration search window (SPRT passed w/ +28 elo)

SPRT STC:
```
--------------------------------------------------
Results of tight-aspiration-window vs syzygy-has-repeated (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: 32.75 +/- 15.53, nElo: 51.17 +/- 24.11
LOS: 100.00 %, DrawRatio: 42.86 %, PairsRatio: 1.68
Games: 798, Wins: 245, Losses: 170, Draws: 383, Points: 436.5 (54.70 %)
Ptnml(0-2): [10, 75, 171, 116, 27], WL/DD Ratio: 0.78
LLR: 2.99 (101.6%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
Finished match
```

SPRT LTC:
```
--------------------------------------------------
Results of tight-aspiration-window vs syzygy-has-repeated (120+1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: 13.25 +/- 8.85, nElo: 22.71 +/- 15.15
LOS: 99.83 %, DrawRatio: 46.24 %, PairsRatio: 1.28
Games: 2020, Wins: 471, Losses: 394, Draws: 1155, Points: 1048.5 (51.91 %)
Ptnml(0-2): [20, 218, 467, 275, 30], WL/DD Ratio: 0.41
LLR: 2.95 (100.1%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
Finished match
```