### PR TITLE
Mate distance pruning

### DIFF
--- a/src/chess-engine-lib/Eval.cpp
+++ b/src/chess-engine-lib/Eval.cpp
@@ -1801,8 +1801,7 @@ EvalT Evaluator::evaluate(const GameState& gameState, const BoardControl& boardC
     const auto rawEvalWhite =
             evaluateForWhite<false>(params_, gameState, boardControl, pawnKingEvalHashTable_);
 
-    const EvalT clampedEvalWhite =
-            (EvalT)clamp((int)rawEvalWhite.value, -kMateEval + 1'000, kMateEval - 1'000);
+    const EvalT clampedEvalWhite = clampNonMateEval((int)rawEvalWhite.value);
 
     return gameState.getSideToMove() == Side::White ? clampedEvalWhite : -clampedEvalWhite;
 }

--- a/src/chess-engine-lib/EvalT.cpp
+++ b/src/chess-engine-lib/EvalT.cpp
@@ -26,8 +26,18 @@ FORCE_INLINE EvalT mateDistancePlus1(const EvalT eval) {
     return (EvalT)(eval - signum(eval));
 }
 
+FORCE_INLINE EvalT mateDistanceMinus1(const EvalT eval) {
+    MY_ASSERT(isMate(eval));
+
+    return (EvalT)(eval + signum(eval));
+}
+
 FORCE_INLINE EvalT mateIn(const int mateDistance) {
     MY_ASSERT(mateDistance >= 0);
 
     return (EvalT)(kMateEval - mateDistance);
+}
+
+FORCE_INLINE EvalT clampNonMateEval(const int eval) {
+    return (EvalT)clamp((int)eval, -kMateEval + 1'000, kMateEval - 1'000);
 }

--- a/src/chess-engine-lib/EvalT.h
+++ b/src/chess-engine-lib/EvalT.h
@@ -16,4 +16,8 @@ inline constexpr EvalT kMateEval     = (EvalT)30'000;
 
 [[nodiscard]] EvalT mateDistancePlus1(EvalT eval);
 
+[[nodiscard]] EvalT mateDistanceMinus1(EvalT eval);
+
 [[nodiscard]] EvalT mateIn(int mateDistance);
+
+[[nodiscard]] EvalT clampNonMateEval(int eval);

--- a/src/chess-engine-lib/MoveOrdering.cpp
+++ b/src/chess-engine-lib/MoveOrdering.cpp
@@ -113,7 +113,8 @@ FORCE_INLINE MoveOrderer::MoveOrderer(
       lastMoveType_(MoveType::None),
       moveToIgnore_(moveToIgnore),
       usingPregeneratedMoves_(!moves_.empty()),
-      foundAnyLegalMoves_(!moves_.empty()) {
+      foundAnyLegalMoves_(!moves_.empty()),
+      skipQuietMoveGeneration_(false) {
     if (usingPregeneratedMoves_) {
         // Use pre-generated moves.
         // This should only happen in the root move and in quiescence search.
@@ -212,6 +213,13 @@ FORCE_INLINE std::optional<Move> MoveOrderer::getNextBestMove(
                 return bestMove;
             }
 
+            if (skipQuietMoveGeneration_) {
+                state_          = State::LosingCaptures;
+                currentMoveIdx_ = firstLosingCaptureIdx_;
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
+                goto skipQuietsLabel;
+            }
+
             state_          = State::InitQuiets;
             currentMoveIdx_ = firstQuietIdx_;
             [[fallthrough]];
@@ -292,7 +300,8 @@ FORCE_INLINE std::optional<Move> MoveOrderer::getNextBestMove(
             [[fallthrough]];
         }
 
-        case State::LosingCaptures: {
+        case State::LosingCaptures:
+        skipQuietsLabel: {
             MY_ASSERT(
                     firstLosingCaptureIdx_ <= currentMoveIdx_ && currentMoveIdx_ <= firstQuietIdx_);
 
@@ -353,10 +362,33 @@ FORCE_INLINE MoveType MoveOrderer::getLastMoveType() const {
     return lastMoveType_;
 }
 
-FORCE_INLINE void MoveOrderer::skipRemainingQuiets() {
-    MY_ASSERT(state_ == State::Quiets);
-    state_          = State::LosingCaptures;
-    currentMoveIdx_ = firstLosingCaptureIdx_;
+FORCE_INLINE bool MoveOrderer::anyLegalMoves(
+        const GameState& gameState, const BoardControl& boardControl) {
+    if (foundAnyLegalMoves_) {
+        return true;
+    }
+    if (usingPregeneratedMoves_ || !skipQuietMoveGeneration_) {
+        return foundAnyLegalMoves_;  // false
+    }
+
+    // We skipped quiet move generation, so we need to check if there are any quiet moves.
+    MY_ASSERT_DEBUG(moves_.empty());
+    moves_.unlock();
+    gameState.generateMoves(
+            moves_, boardControl, MoveCategories::Quiets | MoveCategories::UnderPromotions);
+    moves_.lock();
+
+    foundAnyLegalMoves_ |= !moves_.empty();
+    return foundAnyLegalMoves_;
+}
+
+FORCE_INLINE void MoveOrderer::skipQuiets() {
+    if (state_ == State::GoodTactical) {
+        skipQuietMoveGeneration_ = true;
+    } else if (state_ == State::Quiets) {
+        state_          = State::LosingCaptures;
+        currentMoveIdx_ = firstLosingCaptureIdx_;
+    }
 }
 
 FORCE_INLINE int MoveOrderer::findHighestScoringMove(const int startIdx, const int endIdx) const {

--- a/src/chess-engine-lib/MoveOrdering.cpp
+++ b/src/chess-engine-lib/MoveOrdering.cpp
@@ -113,7 +113,7 @@ FORCE_INLINE MoveOrderer::MoveOrderer(
       lastMoveType_(MoveType::None),
       moveToIgnore_(moveToIgnore),
       usingPregeneratedMoves_(!moves_.empty()),
-      foundAnyLegalMoves_(!moves_.empty()),
+      foundAnyLegalMoves_(!moves_.empty() || moveToIgnore.has_value()),
       skipQuietMoveGeneration_(false) {
     if (usingPregeneratedMoves_) {
         // Use pre-generated moves.

--- a/src/chess-engine-lib/MoveOrdering.h
+++ b/src/chess-engine-lib/MoveOrdering.h
@@ -68,9 +68,9 @@ class MoveOrderer {
     [[nodiscard]] bool lastMoveWasLosing() const;
     [[nodiscard]] MoveType getLastMoveType() const;
 
-    [[nodiscard]] bool hasFoundAnyLegalMoves() const { return foundAnyLegalMoves_; }
+    [[nodiscard]] bool anyLegalMoves(const GameState& gameState, const BoardControl& boardControl);
 
-    void skipRemainingQuiets();
+    void skipQuiets();
 
     static constexpr int kCaptureLosingThreshold = -20;
 
@@ -105,6 +105,7 @@ class MoveOrderer {
 
     bool usingPregeneratedMoves_;
     bool foundAnyLegalMoves_;
+    bool skipQuietMoveGeneration_;
 };
 
 class MoveScorer {

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -964,6 +964,11 @@ EvalT MoveSearcher::Impl::search(
         // considered futile. Let's skip them all.
         moveOrderer.skipQuiets();
 
+        // Since we're skipping the futility value calculation for quiet moves, we need to raise
+        // bestScore so that it is a reasonable upper bound on the position's value. We can simply
+        // raise it to alpha.
+        bestScore = max(bestScore, alpha);
+
         // We'll inflate the move count (for purposes of futility margin calculation) so that
         // skipping the quiet voting process doesn't raise the futility margin applied to losing
         // tactical moves.
@@ -1056,6 +1061,8 @@ EvalT MoveSearcher::Impl::search(
                 gameState.getBoardHash(),
                 isPvNode);
     }
+
+    MY_ASSERT_DEBUG(IMPLIES(!wasInterrupted_, bestScore != -kInfiniteEval));
 
     // If bestScore <= alphaOrig, then all subcalls returned upper bounds and bestScore is the
     // maximum of these upper bounds, so an upper bound on the overall position. This is ok because

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -657,10 +657,7 @@ FORCE_INLINE std::pair<EvalT, bool> MoveSearcher::Impl::getMoveFutilityValue(
             // In this case, we want to avoid returning a futility value based on the eval, because
             // that will cause non-sensical values to be returned (like a mate-in-100). Returning
             // alpha is sufficient to ensure the move is pruned.
-            // We also vote to skip quiets, but we can only do that once we've reached a quiet move,
-            // otherwise we will end up violating an invariant of the move orderer.
-            const bool voteToSkipQuiets = !isTactical;
-            return {alpha, voteToSkipQuiets};
+            return {alpha, false};
         }
     }
 
@@ -958,7 +955,20 @@ EvalT MoveSearcher::Impl::search(
             lastMove,
             ply);
 
-    int votesToSkipQuiets = 0;
+    static constexpr int kVotesToSkipQuietsThreshold = 5;
+    int votesToSkipQuiets                            = 0;
+
+    int losingTacticalAdditionalMoveCount = 0;
+    if (futilityPruningEnabled && isMate(eval) && eval < 0) {
+        // If eval (from TT) indicates a losing mate position, then all quiet moves will be
+        // considered futile. Let's skip them all.
+        moveOrderer.skipQuiets();
+
+        // We'll inflate the move count (for purposes of futility margin calculation) so that
+        // skipping the quiet voting process doesn't raise the futility margin applied to losing
+        // tactical moves.
+        losingTacticalAdditionalMoveCount = kVotesToSkipQuietsThreshold;
+    }
 
     while (const auto maybeMove =
                    moveOrderer.getNextBestMove(gameState, boardControl, lastMove, ply)) {
@@ -969,37 +979,33 @@ EvalT MoveSearcher::Impl::search(
 
         // Futility pruning
         if (futilityPruningEnabled) {
+            const bool isLosingTactical = moveOrderer.lastMoveWasLosing();
+            const int moveCountForFutility =
+                    movesSearched + (isLosingTactical ? losingTacticalAdditionalMoveCount : 0);
+
             const auto [futilityValue, voteToSkip] = getMoveFutilityValue(
                     eval,
                     alpha,
                     depth - reduction,
-                    movesSearched,
+                    moveCountForFutility,
                     move,
-                    moveOrderer.lastMoveWasLosing(),
+                    isLosingTactical,
                     gameState,
                     enemyPinBitBoard,
                     directCheckBitBoards);
 
             if (futilityValue <= alpha) {
-                // Raise bestScore to at least alpha so that we don't return -kInfiniteEval if all
-                // moves are pruned.
-                // We could consider raising the score to futilityValue instead (which would give
-                // us a tighter soft-fail score), but this value may not be meaningful.
-                // In particular, if eval is a mate score (obtained from the ttable), then
-                // futilityValue
+                // Raise bestScore to the futility value so that it is a reasonable upper bound on
+                // the position's value. In particular, this ensures that if all moves are pruned,
+                // we don't return -kInfiniteEval.
                 bestScore = max(bestScore, futilityValue);
 
                 if (voteToSkip) {
                     ++votesToSkipQuiets;
 
                     // Check if we have enough votes to skip remaining quiets.
-                    // If the eval is a mate (which we got from the ttable), there's no need to wait
-                    // to accumulate enough votes, since they'll all go the same way. We still wait
-                    // for the first void so that we only skip after we've seen at least one quiet
-                    // move.
-                    static constexpr int kVotesToSkipQuietsThreshold = 5;
-                    if (votesToSkipQuiets >= kVotesToSkipQuietsThreshold || isMate(eval)) {
-                        moveOrderer.skipRemainingQuiets();
+                    if (votesToSkipQuiets >= kVotesToSkipQuietsThreshold) {
+                        moveOrderer.skipQuiets();
                     }
                 }
 
@@ -1033,7 +1039,7 @@ EvalT MoveSearcher::Impl::search(
         }
     }
 
-    if (!wasInterrupted_ && !moveOrderer.hasFoundAnyLegalMoves()) {
+    if (!wasInterrupted_ && !moveOrderer.anyLegalMoves(gameState, boardControl)) {
         // Exact value
         return updateMateDistanceOut(evaluateNoLegalMoves(gameState));
     }

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -295,10 +295,21 @@ const auto lmrReductionTable = []() {
     return min(lmrFromTable, depth - 1);
 }
 
-FORCE_INLINE void updateMateDistance(EvalT& score) {
-    if (isMate(score)) {
-        score = mateDistancePlus1(score);
+FORCE_INLINE EvalT updateMateDistanceOut(const EvalT score) {
+    if (abs(score) == kInfiniteEval) {
+        return score;
     }
+    if (isMate(score)) {
+        return mateDistancePlus1(score);
+    }
+    return score;
+}
+
+FORCE_INLINE EvalT updateMateDistanceIn(const EvalT score) {
+    if (isMate(score)) {
+        return mateDistanceMinus1(score);
+    }
+    return score;
 }
 
 // Compute the delta between two wrapping counters
@@ -711,12 +722,21 @@ EvalT MoveSearcher::Impl::search(
     if (ply > 0) {
         if (const auto endStateValue = checkForcedEndState(gameState, stack)) {
             // Exact value
-            return *endStateValue;
+            return updateMateDistanceOut(*endStateValue);
         }
     }
 
     const BoardControl boardControl = gameState.getBoardControl();
     const bool isInCheck            = gameState.isInCheck(boardControl);
+
+    // Mate distance pruning: check for impossible mate
+    if (kMateEval < alpha) {
+        return updateMateDistanceOut(kMateEval);
+    }
+    const EvalT worstCaseMate = isInCheck ? -kMateEval : -mateIn(2);
+    if (worstCaseMate > beta) {
+        return updateMateDistanceOut(worstCaseMate);
+    }
 
     const int extension = getDepthExtension(isInCheck, lastMove);
     if (ply > 0) {
@@ -750,7 +770,7 @@ EvalT MoveSearcher::Impl::search(
 
         if (futilityValue >= beta) {
             // Return a conservative lower bound (fail-hard).
-            return beta;
+            return updateMateDistanceOut(beta);
         }
     }
 
@@ -775,7 +795,7 @@ EvalT MoveSearcher::Impl::search(
         // However, if we're at the root, force a further search to get at least one move in the PV.
         if (ttInfo.scoreType == ScoreType::EGTB && ply > 0) {
             // Exact value
-            return ttInfo.score;
+            return updateMateDistanceOut(ttInfo.score);
         }
 
         if (ttInfo.depth >= depth) {
@@ -785,13 +805,13 @@ EvalT MoveSearcher::Impl::search(
                             max(searchStatistics_.selectiveDepth, ply + ttInfo.depth);
                 }
                 // Exact value
-                return ttInfo.score;
+                return updateMateDistanceOut(ttInfo.score);
             } else if (ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta) {
                 // Lower bound
-                return ttInfo.score;
+                return updateMateDistanceOut(ttInfo.score);
             } else if (ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha) {
                 // Upper bound
-                return ttInfo.score;
+                return updateMateDistanceOut(ttInfo.score);
             }
         }
 
@@ -819,7 +839,7 @@ EvalT MoveSearcher::Impl::search(
 
             storeEgtbValueInTTable(tbScore, depth, gameState.getBoardHash());
 
-            return tbScore;
+            return updateMateDistanceOut(tbScore);
         }
     }
 
@@ -829,20 +849,18 @@ EvalT MoveSearcher::Impl::search(
 
         const auto unmakeInfo = gameState.makeNullMove();
 
-        EvalT nullMoveScore =
+        const EvalT nullMoveScore =
                 -search(gameState,
                         nullMoveSearchDepth,
                         ply + 1,
-                        -beta,
-                        -beta + 1,
+                        updateMateDistanceIn(-beta),
+                        updateMateDistanceIn(-beta + 1),
                         /*lastMove =*/{},
                         /*lastNullMovePly =*/ply,
                         NodeType::AllNode,
                         stack);
 
         gameState.unmakeNullMove(unmakeInfo);
-
-        updateMateDistance(nullMoveScore);
 
         if (wasInterrupted_) {
             return -kInfiniteEval;
@@ -853,7 +871,7 @@ EvalT MoveSearcher::Impl::search(
 
             // Null move failed high, don't bother searching other moves.
             // Return a conservative lower bound (fail-hard).
-            return beta;
+            return updateMateDistanceOut(beta);
         }
     }
 
@@ -882,7 +900,7 @@ EvalT MoveSearcher::Impl::search(
                 /*useScoutSearch =*/false);
 
         if (outcome == SearchMoveOutcome::Interrupted) {
-            return bestScore;
+            return updateMateDistanceOut(bestScore);
         }
 
         ++movesSearched;
@@ -903,7 +921,7 @@ EvalT MoveSearcher::Impl::search(
             // Score was obtained from a subcall that failed high, so it was a lower bound for
             // that position. It is also a lower bound for the overall position because we're
             // maximizing.
-            return bestScore;
+            return updateMateDistanceOut(bestScore);
         }
     }
 
@@ -991,7 +1009,7 @@ EvalT MoveSearcher::Impl::search(
 
     if (!wasInterrupted_ && !moveOrderer.hasFoundAnyLegalMoves()) {
         // Exact value
-        return evaluateNoLegalMoves(gameState);
+        return updateMateDistanceOut(evaluateNoLegalMoves(gameState));
     }
 
     if (movesSearched > 0) {
@@ -1033,7 +1051,7 @@ EvalT MoveSearcher::Impl::search(
     //
     // If we're failing high relative to the original beta then we found a lower bound outside the
     // feasibility window so we can safely return a lower bound.
-    return bestScore;
+    return updateMateDistanceOut(bestScore);
 }
 
 // Quiescence search. When in check search all moves, when not in check only search captures.
@@ -1052,7 +1070,7 @@ EvalT MoveSearcher::Impl::quiesce(
     Move bestMove{};
 
     if (shouldStopSearch()) {
-        return bestScore;
+        return -kInfiniteEval;
     }
 
     ++searchStatistics_.qNodesSearched;
@@ -1064,11 +1082,20 @@ EvalT MoveSearcher::Impl::quiesce(
     }
 
     if (const auto endStateValue = checkForcedEndState(gameState, stack)) {
-        return *endStateValue;
+        return updateMateDistanceOut(*endStateValue);
     }
 
     const BoardControl boardControl = gameState.getBoardControl();
     const bool isInCheck            = gameState.isInCheck(boardControl);
+
+    // Mate distance pruning: check for impossible mate
+    if (kMateEval < alpha) {
+        return updateMateDistanceOut(kMateEval);
+    }
+    const EvalT worstCaseMate = isInCheck ? -kMateEval : -mateIn(2);
+    if (worstCaseMate > beta) {
+        return updateMateDistanceOut(worstCaseMate);
+    }
 
     bool completedAnySearch = false;
     const EvalT alphaOrig   = alpha;
@@ -1076,14 +1103,14 @@ EvalT MoveSearcher::Impl::quiesce(
     EvalT standPat = -kInfiniteEval;
     if (!isInCheck) {
         // Stand pat
-        standPat  = evaluator_.evaluate(gameState, boardControl);
-        bestScore = standPat;
-        if (bestScore >= beta) {
-            return bestScore;
+        standPat = evaluator_.evaluate(gameState, boardControl);
+        if (standPat >= beta) {
+            return standPat;
         }
+        bestScore = standPat;
 
         static constexpr int kStandPatDeltaPruningThreshold = 1'000;
-        const EvalT deltaPruningScore = standPat + kStandPatDeltaPruningThreshold;
+        const EvalT deltaPruningScore = clampNonMateEval(standPat + kStandPatDeltaPruningThreshold);
         if (deltaPruningScore < alpha) {
             // Stand pat is so far below alpha that we have no hope of raising it even if we find a
             // good capture. Return the stand pat evaluation plus a large margin.
@@ -1119,7 +1146,7 @@ EvalT MoveSearcher::Impl::quiesce(
 
         if (ttInfo.scoreType == ScoreType::Exact || ttInfo.scoreType == ScoreType::EGTB) {
             // Exact value
-            return ttInfo.score;
+            return updateMateDistanceOut(ttInfo.score);
         } else if (ttInfo.scoreType == ScoreType::LowerBound) {
             // Can safely raise the lower bound for our search window, because the true value
             // is guaranteed to be above this bound.
@@ -1140,7 +1167,7 @@ EvalT MoveSearcher::Impl::quiesce(
             // If beta was lowered by the tt entry this is an upper bound and we want to return
             // that lowered beta (fail-soft: that's the tightest upper bound we have).
             // So either way we return the tt entry score.
-            return ttInfo.score;
+            return updateMateDistanceOut(ttInfo.score);
         }
 
         hashMove = getTTableMove(ttInfo, gameState);
@@ -1188,15 +1215,19 @@ EvalT MoveSearcher::Impl::quiesce(
             tTable_.prefetch(gameState.getBoardHash());
             evaluator_.prefetch(gameState);
 
-            EvalT score = -quiesce(gameState, -beta, -alpha, ply + 1, (NodeType)-nodeType, stack);
+            const EvalT score = -quiesce(
+                    gameState,
+                    updateMateDistanceIn(-beta),
+                    updateMateDistanceIn(-alpha),
+                    ply + 1,
+                    (NodeType)-nodeType,
+                    stack);
 
             gameState.unmakeMove(*hashMove, unmakeInfo);
 
             if (wasInterrupted_) {
-                return bestScore;
+                return updateMateDistanceOut(bestScore);
             }
-
-            updateMateDistance(score);
 
             completedAnySearch = true;
             bestScore          = max(bestScore, score);
@@ -1216,7 +1247,7 @@ EvalT MoveSearcher::Impl::quiesce(
                             gameState.getBoardHash(),
                             isPvNode);
 
-                    return score;
+                    return updateMateDistanceOut(score);
                 }
             }
         }
@@ -1228,7 +1259,7 @@ EvalT MoveSearcher::Impl::quiesce(
         if (isInCheck) {
             // We ran full move generation, so no legal moves exist, and we're in check, so it's a
             // checkmate.
-            return -kMateEval;
+            return updateMateDistanceOut(-kMateEval);
         }
 
         // No captures are available.
@@ -1244,7 +1275,7 @@ EvalT MoveSearcher::Impl::quiesce(
         }
 
         // If we're not in an end state return the stand pat evaluation.
-        return bestScore;
+        return updateMateDistanceOut(bestScore);
     }
 
     // Ignore the hash move even if we didn't try it, since that would mean we pruned it.
@@ -1294,15 +1325,19 @@ EvalT MoveSearcher::Impl::quiesce(
         tTable_.prefetch(gameState.getBoardHash());
         evaluator_.prefetch(gameState);
 
-        EvalT score = -quiesce(gameState, -beta, -alpha, ply + 1, (NodeType)-nodeType, stack);
+        const EvalT score = -quiesce(
+                gameState,
+                updateMateDistanceIn(-beta),
+                updateMateDistanceIn(-alpha),
+                ply + 1,
+                (NodeType)-nodeType,
+                stack);
 
         gameState.unmakeMove(move, unmakeInfo);
 
         if (wasInterrupted_) {
             break;
         }
-
-        updateMateDistance(score);
 
         completedAnySearch = true;
 
@@ -1330,7 +1365,7 @@ EvalT MoveSearcher::Impl::quiesce(
                 isPvNode);
     }
 
-    return bestScore;
+    return updateMateDistanceOut(bestScore);
 }
 
 FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMove(
@@ -1367,8 +1402,8 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
                 -search(gameState,
                         reducedDepth,
                         ply + 1,
-                        -alpha - 1,
-                        -alpha,
+                        updateMateDistanceIn(-alpha - 1),
+                        updateMateDistanceIn(-alpha),
                         move,
                         lastNullMovePly,
                         NodeType::CutNode,
@@ -1380,8 +1415,8 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
                     -search(gameState,
                             fullDepth,
                             ply + 1,
-                            -alpha - 1,
-                            -alpha,
+                            updateMateDistanceIn(-alpha - 1),
+                            updateMateDistanceIn(-alpha),
                             move,
                             lastNullMovePly,
                             NodeType::CutNode,
@@ -1394,8 +1429,8 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
                     -search(gameState,
                             fullDepth,
                             ply + 1,
-                            -beta,
-                            -alpha,
+                            updateMateDistanceIn(-beta),
+                            updateMateDistanceIn(-alpha),
                             move,
                             lastNullMovePly,
                             NodeType::PvNode,
@@ -1408,8 +1443,8 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
                 -search(gameState,
                         reducedDepth,
                         ply + 1,
-                        -beta,
-                        -alpha,
+                        updateMateDistanceIn(-beta),
+                        updateMateDistanceIn(-alpha),
                         move,
                         lastNullMovePly,
                         (NodeType)-currentNodeType,
@@ -1421,8 +1456,6 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
     if (wasInterrupted_) {
         return SearchMoveOutcome::Interrupted;
     }
-
-    updateMateDistance(score);
 
     if (score > bestScore) {
         bestScore = score;
@@ -1459,7 +1492,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
     int upperTolerance = kInitialTolerance;
 
     auto toEval = [](int v) {
-        return (EvalT)(clamp(v, (int)-kInfiniteEval, (int)kInfiniteEval));
+        return (EvalT)(clamp(v, (int)-kMateEval, (int)kMateEval));
     };
 
     EvalT lowerBound = toEval(initialGuess - lowerTolerance);
@@ -1539,7 +1572,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
             if (isMate(searchEval) && searchEval < 0) {
                 // If we found a mate, fully open up the window to the mating side.
                 // This will allow us to find the earliest mate.
-                lowerBound = -kInfiniteEval;
+                lowerBound = -kMateEval;
             } else {
                 // Exponentially grow the tolerance.
                 const int oldTolerance = lowerTolerance;
@@ -1553,7 +1586,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
             if (isMate(searchEval) && searchEval > 0) {
                 // If we found a mate, fully open up the window to the mating side.
                 // This will allow us to find the earliest mate.
-                upperBound = kInfiniteEval;
+                upperBound = kMateEval;
             } else {
                 // Exponentially grow the tolerance.
                 const int oldTolerance = upperTolerance;
@@ -1612,8 +1645,8 @@ RootSearchResult MoveSearcher::Impl::searchForBestMove(
                 search(gameState,
                        depth,
                        0,
-                       -kInfiniteEval,
-                       kInfiniteEval,
+                       -kMateEval,
+                       kMateEval,
                        /*lastMove =*/{},
                        /*lastNullMovePly =*/INT_MIN,
                        NodeType::PvNode,

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -637,6 +637,7 @@ FORCE_INLINE std::pair<EvalT, bool> MoveSearcher::Impl::getMoveFutilityValue(
         std::optional<GameState::DirectCheckBitBoards>& directCheckBitBoards) {
     const bool isTactical = isCaptureOrQueenPromo(move);
     MY_ASSERT(IMPLIES(isLosingTactical, isTactical));
+    MY_ASSERT_DEBUG(!isMate(alpha));
 
     if (isTactical && !isLosingTactical) {
         // Don't futility prune winning tactical moves.
@@ -645,6 +646,22 @@ FORCE_INLINE std::pair<EvalT, bool> MoveSearcher::Impl::getMoveFutilityValue(
     if (isCapture(move) && captureWillProbeSyzygy(gameState, reducedDepth)) {
         // We will get a fast and accurate value from syzygy probe, so no point pruning this move.
         return {kMateEval, false};
+    }
+    if (isMate(eval)) {
+        if (eval > 0) {
+            // Eval (from TT) indicates a winning mate position, so we can't reasonably prune any moves.
+            return {kMateEval, false};
+        } else {
+            // Eval (from TT) indicates a losing mate position, let's prune all moves (except
+            // winning tactical moves, which we already handled above).
+            // In this case, we want to avoid returning a futility value based on the eval, because
+            // that will cause non-sensical values to be returned (like a mate-in-100). Returning
+            // alpha is sufficient to ensure the move is pruned.
+            // We also vote to skip quiets, but we can only do that once we've reached a quiet move,
+            // otherwise we will end up violating an invariant of the move orderer.
+            const bool voteToSkipQuiets = !isTactical;
+            return {alpha, voteToSkipQuiets};
+        }
     }
 
     const EvalT futilityMargin = calculateFutilityMargin(reducedDepth, movesSearched, isTactical);
@@ -964,15 +981,24 @@ EvalT MoveSearcher::Impl::search(
                     directCheckBitBoards);
 
             if (futilityValue <= alpha) {
-                if (futilityValue > bestScore) {
-                    bestScore = futilityValue;
-                }
+                // Raise bestScore to at least alpha so that we don't return -kInfiniteEval if all
+                // moves are pruned.
+                // We could consider raising the score to futilityValue instead (which would give
+                // us a tighter soft-fail score), but this value may not be meaningful.
+                // In particular, if eval is a mate score (obtained from the ttable), then
+                // futilityValue
+                bestScore = max(bestScore, futilityValue);
 
                 if (voteToSkip) {
                     ++votesToSkipQuiets;
 
+                    // Check if we have enough votes to skip remaining quiets.
+                    // If the eval is a mate (which we got from the ttable), there's no need to wait
+                    // to accumulate enough votes, since they'll all go the same way. We still wait
+                    // for the first void so that we only skip after we've seen at least one quiet
+                    // move.
                     static constexpr int kVotesToSkipQuietsThreshold = 5;
-                    if (votesToSkipQuiets >= kVotesToSkipQuietsThreshold) {
+                    if (votesToSkipQuiets >= kVotesToSkipQuietsThreshold || isMate(eval)) {
                         moveOrderer.skipRemainingQuiets();
                     }
                 }
@@ -1176,7 +1202,12 @@ EvalT MoveSearcher::Impl::quiesce(
         if (hashMove && !isInCheck) {
             if (!isCapture(hashMove->flags)) {
                 shouldTryHashMove = false;
-            } else {
+            } else if (!isMate(alpha)) {
+                // Delta pruning.
+                // We skip delta pruning if alpha is a mate score, since in that case we're looking
+                // for a mate, and can't prune moves based purely on material exchange
+                // considerations.
+
                 // Let deltaPruningScore = standPat + SEE + kDeltaPruningThreshold
                 // if deltaPruningScore < alpha, we can prune the move if it doesn't give check
                 // So we need to check if SEE >= alpha - standPat - kDeltaPruningThreshold
@@ -1195,7 +1226,7 @@ EvalT MoveSearcher::Impl::quiesce(
                     // function if we prune moves is still reliable. Note that this is definitely below
                     // alpha.
                     const EvalT deltaPruningScore =
-                            (EvalT)(standPat + seeBound + kDeltaPruningThreshold);
+                            clampNonMateEval(standPat + seeBound + kDeltaPruningThreshold);
                     bestScore = max(bestScore, deltaPruningScore);
 
                     if (!directCheckBitBoards) {
@@ -1285,8 +1316,10 @@ EvalT MoveSearcher::Impl::quiesce(
     while (const auto maybeMove = moveOrderer.getNextBestMoveQuiescence()) {
         const Move move = *maybeMove;
 
-        if (!isInCheck) {
+        if (!isInCheck && !isMate(alpha)) {
             // Delta pruning
+            // We skip delta pruning if alpha is a mate score, since in that case we're looking for
+            // a mate, and can't prune moves based purely on material exchange considerations.
 
             MY_ASSERT(isCapture(move));
 
@@ -1307,7 +1340,7 @@ EvalT MoveSearcher::Impl::quiesce(
                 // function if we prune moves is still reliable. Note that this is definitely below
                 // alpha.
                 const EvalT deltaPruningScore =
-                        (EvalT)(standPat + seeBound + kDeltaPruningThreshold);
+                        clampNonMateEval(standPat + seeBound + kDeltaPruningThreshold);
                 bestScore = max(bestScore, deltaPruningScore);
 
                 if (!directCheckBitBoards) {
@@ -1491,7 +1524,7 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
     int lowerTolerance = kInitialTolerance;
     int upperTolerance = kInitialTolerance;
 
-    auto toEval = [](int v) {
+    const auto toEval = [](const int v) {
         return (EvalT)(clamp(v, (int)-kMateEval, (int)kMateEval));
     };
 
@@ -1503,6 +1536,15 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
     EvalT lastCompletedEval = -kInfiniteEval;
 
     do {
+        // If the bounds are mate scores, fully open up the bound to the mating side to allow
+        // finding the fastest mate sequence.
+        if (isMate(lowerBound) && lowerBound < 0) {
+            lowerBound = -kMateEval;
+        }
+        if (isMate(upperBound) && upperBound > 0) {
+            upperBound = kMateEval;
+        }
+
         const auto searchEval =
                 search(gameState,
                        depth,
@@ -1569,32 +1611,20 @@ RootSearchResult MoveSearcher::Impl::aspirationWindowSearch(
 
         if (searchEval <= lowerBound) {
             // Failed low
-            if (isMate(searchEval) && searchEval < 0) {
-                // If we found a mate, fully open up the window to the mating side.
-                // This will allow us to find the earliest mate.
-                lowerBound = -kMateEval;
-            } else {
-                // Exponentially grow the tolerance.
-                const int oldTolerance = lowerTolerance;
-                lowerTolerance *= kToleranceIncreaseFactor;
-                // Expand the lower bound based on the increased tolerance or the search result,
-                // whichever is lower.
-                lowerBound = toEval(min(searchEval - oldTolerance, initialGuess - lowerTolerance));
-            }
+            // Exponentially grow the tolerance.
+            const int oldTolerance = lowerTolerance;
+            lowerTolerance *= kToleranceIncreaseFactor;
+            // Expand the lower bound based on the increased tolerance or the search result,
+            // whichever is lower.
+            lowerBound = toEval(min(searchEval - oldTolerance, initialGuess - lowerTolerance));
         } else {
             // Failed high
-            if (isMate(searchEval) && searchEval > 0) {
-                // If we found a mate, fully open up the window to the mating side.
-                // This will allow us to find the earliest mate.
-                upperBound = kMateEval;
-            } else {
-                // Exponentially grow the tolerance.
-                const int oldTolerance = upperTolerance;
-                upperTolerance *= kToleranceIncreaseFactor;
-                // Expand the upper bound based on the increased tolerance or the search result,
-                // whichever is higher.
-                upperBound = toEval(max(searchEval + oldTolerance, initialGuess + upperTolerance));
-            }
+            // Exponentially grow the tolerance.
+            const int oldTolerance = upperTolerance;
+            upperTolerance *= kToleranceIncreaseFactor;
+            // Expand the upper bound based on the increased tolerance or the search result,
+            // whichever is higher.
+            upperBound = toEval(max(searchEval + oldTolerance, initialGuess + upperTolerance));
         }
 
         if (frontEnd_) {

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -958,21 +958,10 @@ EvalT MoveSearcher::Impl::search(
     static constexpr int kVotesToSkipQuietsThreshold = 5;
     int votesToSkipQuiets                            = 0;
 
-    int losingTacticalAdditionalMoveCount = 0;
     if (futilityPruningEnabled && isMate(eval) && eval < 0) {
         // If eval (from TT) indicates a losing mate position, then all quiet moves will be
         // considered futile. Let's skip them all.
         moveOrderer.skipQuiets();
-
-        // Since we're skipping the futility value calculation for quiet moves, we need to raise
-        // bestScore so that it is a reasonable upper bound on the position's value. We can simply
-        // raise it to alpha.
-        bestScore = max(bestScore, alpha);
-
-        // We'll inflate the move count (for purposes of futility margin calculation) so that
-        // skipping the quiet voting process doesn't raise the futility margin applied to losing
-        // tactical moves.
-        losingTacticalAdditionalMoveCount = kVotesToSkipQuietsThreshold;
     }
 
     while (const auto maybeMove =
@@ -984,17 +973,13 @@ EvalT MoveSearcher::Impl::search(
 
         // Futility pruning
         if (futilityPruningEnabled) {
-            const bool isLosingTactical = moveOrderer.lastMoveWasLosing();
-            const int moveCountForFutility =
-                    movesSearched + (isLosingTactical ? losingTacticalAdditionalMoveCount : 0);
-
             const auto [futilityValue, voteToSkip] = getMoveFutilityValue(
                     eval,
                     alpha,
                     depth - reduction,
-                    moveCountForFutility,
+                    movesSearched,
                     move,
-                    isLosingTactical,
+                    moveOrderer.lastMoveWasLosing(),
                     gameState,
                     enemyPinBitBoard,
                     directCheckBitBoards);
@@ -1044,13 +1029,24 @@ EvalT MoveSearcher::Impl::search(
         }
     }
 
-    if (!wasInterrupted_ && !moveOrderer.anyLegalMoves(gameState, boardControl)) {
+    const bool anyLegalMoves = moveOrderer.anyLegalMoves(gameState, boardControl);
+
+    if (!wasInterrupted_ && !anyLegalMoves) {
         // Exact value
-        return updateMateDistanceOut(evaluateNoLegalMoves(gameState));
+        bestScore = evaluateNoLegalMoves(gameState);
     }
 
-    if (movesSearched > 0) {
-        // If we fully evaluated any positions, update the ttable.
+    if (bestScore == -kInfiniteEval && !wasInterrupted_ && anyLegalMoves) {
+        MY_ASSERT_DEBUG(movesSearched == 0);
+        // All moves were pruned away.
+        // Raise bestScore to alpha to avoid returning -kInfiniteEval.
+        bestScore = alpha;
+    }
+
+    if (movesSearched > 0 || !wasInterrupted_) {
+        MY_ASSERT_DEBUG(bestScore != -kInfiniteEval);
+        // If we were not interrupted, or if we were but we fully evaluated any moves, updated the
+        // ttable.
         updateTTable(
                 bestScore,
                 alphaOrig,

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -654,10 +654,8 @@ FORCE_INLINE std::pair<EvalT, bool> MoveSearcher::Impl::getMoveFutilityValue(
         } else {
             // Eval (from TT) indicates a losing mate position, let's prune all moves (except
             // winning tactical moves, which we already handled above).
-            // In this case, we want to avoid returning a futility value based on the eval, because
-            // that will cause non-sensical values to be returned (like a mate-in-100). Returning
-            // alpha is sufficient to ensure the move is pruned.
-            return {alpha, false};
+            // We still want the score to be a reasonable upper bound, so we clamp to non-mate eval.
+            return {clampNonMateEval(eval), false};
         }
     }
 
@@ -955,14 +953,13 @@ EvalT MoveSearcher::Impl::search(
             lastMove,
             ply);
 
-    static constexpr int kVotesToSkipQuietsThreshold = 5;
-    int votesToSkipQuiets                            = 0;
-
     if (futilityPruningEnabled && isMate(eval) && eval < 0) {
         // If eval (from TT) indicates a losing mate position, then all quiet moves will be
         // considered futile. Let's skip them all.
         moveOrderer.skipQuiets();
     }
+
+    int votesToSkipQuiets = 0;
 
     while (const auto maybeMove =
                    moveOrderer.getNextBestMove(gameState, boardControl, lastMove, ply)) {
@@ -994,6 +991,7 @@ EvalT MoveSearcher::Impl::search(
                     ++votesToSkipQuiets;
 
                     // Check if we have enough votes to skip remaining quiets.
+                    static constexpr int kVotesToSkipQuietsThreshold = 5;
                     if (votesToSkipQuiets >= kVotesToSkipQuietsThreshold) {
                         moveOrderer.skipQuiets();
                     }
@@ -1039,14 +1037,16 @@ EvalT MoveSearcher::Impl::search(
     if (bestScore == -kInfiniteEval && !wasInterrupted_ && anyLegalMoves) {
         MY_ASSERT_DEBUG(movesSearched == 0);
         // All moves were pruned away.
-        // Raise bestScore to alpha to avoid returning -kInfiniteEval.
-        bestScore = alpha;
+        // Raise bestScore to avoid returning -kInfiniteEval.
+        // If we have an eval (either static or from TTable), use that; but clamp it to a non-mate
+        // value to avoid returning an uncertain mate score.
+        // If we don't have an eval, return fail-hard alpha.
+        bestScore = eval != -kInfiniteEval ? clampNonMateEval(eval) : alpha;
     }
 
-    if (movesSearched > 0 || !wasInterrupted_) {
+    if (movesSearched > 0) {
         MY_ASSERT_DEBUG(bestScore != -kInfiniteEval);
-        // If we were not interrupted, or if we were but we fully evaluated any moves, updated the
-        // ttable.
+        // If we fully evaluated any moves, update the ttable.
         updateTTable(
                 bestScore,
                 alphaOrig,

--- a/src/chess-engine-lib/TimeManager.cpp
+++ b/src/chess-engine-lib/TimeManager.cpp
@@ -104,7 +104,7 @@ bool TimeManager::shouldStopAfterMateFound(int depth, int mateDistanceInPly) con
     MY_ASSERT(mode_ != TimeManagementMode::None);
 
     if (mode_ == TimeManagementMode::TimeControl) {
-        return mateDistanceInPly <= depth;
+        return 3 * mateDistanceInPly <= depth;
     }
 
     return false;

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "no-all-node-hash-move");
+            UciFrontEnd uciFrontEnd(engine, "mate-distance-pruning");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {

--- a/src/tuner/PreProcessing.cpp
+++ b/src/tuner/PreProcessing.cpp
@@ -33,10 +33,21 @@ bool isDraw(const GameState& gameState, StackOfVectors<Move>& stack) {
     return false;
 }
 
-void updateMateDistance(EvalT& score) {
-    if (isMate(score)) {
-        score = mateDistancePlus1(score);
+FORCE_INLINE EvalT updateMateDistanceOut(const EvalT score) {
+    if (abs(score) == kInfiniteEval) {
+        return score;
     }
+    if (isMate(score)) {
+        return mateDistancePlus1(score);
+    }
+    return score;
+}
+
+FORCE_INLINE EvalT updateMateDistanceIn(const EvalT score) {
+    if (isMate(score)) {
+        return mateDistanceMinus1(score);
+    }
+    return score;
 }
 
 std::pair<EvalT, GameState> quiesce(
@@ -71,7 +82,7 @@ std::pair<EvalT, GameState> quiesce(
             stack, boardControl, isInCheck ? MoveCategories::All : MoveCategories::Captures);
     if (moves.size() == 0) {
         if (isInCheck) {
-            return {-kMateEval, gameState};
+            return {updateMateDistanceOut(-kMateEval), gameState};
         }
 
         const auto allMoves = gameState.generateMoves(stack, boardControl);
@@ -80,7 +91,7 @@ std::pair<EvalT, GameState> quiesce(
             return {0, gameState};
         }
 
-        return {bestScore, bestState};
+        return {updateMateDistanceOut(bestScore), bestState};
     }
 
     auto moveOrderer = moveScorer.getMoveOrdererQuiescence(
@@ -91,12 +102,16 @@ std::pair<EvalT, GameState> quiesce(
 
         const auto unmakeInfo = gameState.makeMove(move);
 
-        auto [score, state] = quiesce(gameState, -beta, -alpha, stack, moveScorer, evaluator);
-        score               = -score;
+        auto [score, state] =
+                quiesce(gameState,
+                        updateMateDistanceIn(-beta),
+                        updateMateDistanceIn(-alpha),
+                        stack,
+                        moveScorer,
+                        evaluator);
+        score = -score;
 
         gameState.unmakeMove(move, unmakeInfo);
-
-        updateMateDistance(score);
 
         alpha = max(alpha, score);
         if (score > bestScore) {
@@ -109,7 +124,7 @@ std::pair<EvalT, GameState> quiesce(
         }
     }
 
-    return {bestScore, bestState};
+    return {updateMateDistanceOut(bestScore), bestState};
 }
 
 }  // namespace


### PR DESCRIPTION
Add mate distance pruning. Also allow the engine to search a bit longer after finding a mate. With MDP, this should now be pretty quick.

MDP seems to work well. E.g., take the following position (taken from vondele/matetrack):
```
uci
setoption name hash value 512
position fen 5nrn/p3N3/2B1p1p1/2P1kbB1/N3p2r/2K5/4PP2/8 w - - 0 1
go infinite
```

Before: takes 30 seconds to find a mate, and it's not the right mate (but the PV is correct as far as it goes).
We also have a non-sensical 'mate 347 lowerbound'
```
...
info depth 16 seldepth 22 score cp 1177 lowerbound nodes 1429714 time 369 nps 3874564 hashfull 12
info depth 16 seldepth 22 score mate 347 lowerbound nodes 1429845 time 369 nps 3874919 hashfull 12
info depth 16 seldepth 22 score mate 8 nodes 161608543 time 29657 nps 5449255 hashfull 791 pv c6a8 h4h3 f2f3 f5g4 a4b2 h3f3 e2f3
info depth 17 seldepth 8 score mate 8 nodes 918809342 time 166110 nps 5531331 hashfull 1000 pv c6a8 h4h3 f2f3 h3f3 e2f3
...
```

After: takes ~500 ms to find the right mate score, and a correct PV leading to mate.
The lowerbound score (mate 8) now also makes sense.
```
info depth 16 seldepth 22 score cp 1177 lowerbound nodes 1429712 time 371 nps 3853671 hashfull 12
info depth 16 seldepth 22 score mate 8 lowerbound nodes 1429843 time 371 nps 3854024 hashfull 12
info depth 16 seldepth 22 score mate 5 nodes 3485153 time 547 nps 6371395 hashfull 20 pv c6a8 f5g4 f2f4 e4f3 a4b2 g4f5 e2e4 f5e4 b2c4
info depth 17 seldepth 9 score mate 5 nodes 6641964 time 798 nps 8323264 hashfull 25 pv c6a8 f5g4 f2f4 e4f3 a4b2 g4f5 e2e4 f5e4 b2c4
...
```

In regular play the engine is slightly weakened; failed to pass non-regression SPRT (-5, 0; terminated early):
```
--------------------------------------------------
Results of mate-distance-pruning vs no-all-node-hash-move (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: -2.64 +/- 2.45, nElo: -4.01 +/- 3.72
LOS: 1.73 %, DrawRatio: 43.03 %, PairsRatio: 0.96
Games: 33524, Wins: 9127, Losses: 9382, Draws: 15015, Points: 16634.5 (49.62 %)
Ptnml(0-2): [870, 4001, 7212, 3872, 807], WL/DD Ratio: 1.02
LLR: -2.09 (-71.1%) (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
```
The 2-3 elo strength loss seems like a worthwhile trade-off for the improved mate-finding performance.
