### PR TITLE
More tt pv cutoffs

### DIFF
--- a/src/chess-engine-lib/EvalT.h
+++ b/src/chess-engine-lib/EvalT.h
@@ -6,7 +6,7 @@
 
 using EvalT = std::int16_t;
 
-enum ScoreType : std::uint8_t {
+enum class ScoreType : std::uint8_t {
     NotSet     = 0,
     Exact      = 1,
     LowerBound = 2,

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -1336,6 +1336,8 @@ EvalT MoveSearcher::Impl::quiesce(
             bestMove = move;
 
             if (alpha >= beta) {
+                pvTable_.clearPv(ply);
+
                 break;
             }
 
@@ -1485,6 +1487,8 @@ FORCE_INLINE MoveSearcher::Impl::SearchMoveOutcome MoveSearcher::Impl::searchMov
             bestMove = move;
 
             if (score >= beta) {
+                pvTable_.clearPv(ply);
+
                 moveScorer_.reportCutoff(move, gameState, moveType, lastMove, ply, depth);
 
                 // Fail high; score is a lower bound.

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -899,14 +899,19 @@ EvalT MoveSearcher::Impl::search(
         //  - We want to get a full PV.
         //  - The stored values may be heuristic bounds from pruning techniques that we disallow in
         //    PV nodes, so we don't want to use those values.
-        if (ttInfo.depth >= depth && !isPvNode) {
-            if (ttInfo.scoreType == ScoreType::Exact) {
+        if (ttInfo.depth >= depth) {
+            if (ttInfo.scoreType == ScoreType::Exact
+                && (!isPvNode || ttInfo.score < alpha || ttInfo.score >= beta)) {
                 // Exact value
                 return updateMateDistanceOut(ttInfo.score);
-            } else if (ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta) {
+            } else if (
+                    ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta
+                    && !isPvNode) {
                 // Lower bound
                 return updateMateDistanceOut(ttInfo.score);
-            } else if (ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha) {
+            } else if (
+                    ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha
+                    && !isPvNode) {
                 // Upper bound
                 return updateMateDistanceOut(ttInfo.score);
             }
@@ -917,7 +922,7 @@ EvalT MoveSearcher::Impl::search(
             eval = ttInfo.score;
         } else if (ttInfo.scoreType == ScoreType::LowerBound) {
             eval = max(eval, ttInfo.score);
-        } else if (ttInfo.scoreType == UpperBound) {
+        } else if (ttInfo.scoreType == ScoreType::UpperBound) {
             eval = min(eval, ttInfo.score);
         }
 
@@ -1236,35 +1241,21 @@ EvalT MoveSearcher::Impl::quiesce(
 
         searchStatistics_.tTableHits++;
 
-        // In non-PV nodes: check for TT cut-offs.
-        if (!isPvNode) {
-            // No need to check depth: in qsearch, depth == 0.
-
-            if (ttInfo.scoreType == ScoreType::Exact || ttInfo.scoreType == ScoreType::EGTB) {
-                // Exact value
-                return updateMateDistanceOut(ttInfo.score);
-            } else if (ttInfo.scoreType == ScoreType::LowerBound) {
-                // Can safely raise the lower bound for our search window, because the true value
-                // is guaranteed to be above this bound.
-                alpha = max(alpha, ttInfo.score);
-            } else if (ttInfo.scoreType == ScoreType::UpperBound) {
-                // Can safely lower the upper bound for our search window, because the true value
-                // is guaranteed to be below this bound.
-                beta = min(beta, ttInfo.score);
-            }
-            // Else: score type not set (result from interrupted search).
-
-            // Check if we can return based on tighter bounds from the transposition table.
-            if (alpha >= beta) {
-                // Based on information from the ttable, we now know that the true value is outside
-                // of the feasibility window.
-                // If alpha was raised by the tt entry this is a lower bound and we want to return
-                // that raised alpha (fail-soft: that's the tightest lower bound we have).
-                // If beta was lowered by the tt entry this is an upper bound and we want to return
-                // that lowered beta (fail-soft: that's the tightest upper bound we have).
-                // So either way we return the tt entry score.
-                return updateMateDistanceOut(ttInfo.score);
-            }
+        // No need to check depth: in qsearch, depth == 0.
+        if (ttInfo.scoreType == ScoreType::EGTB) {
+            // Exact value
+            return updateMateDistanceOut(ttInfo.score);
+        } else if (
+                ttInfo.scoreType == ScoreType::Exact
+                && (!isPvNode || ttInfo.score < alpha || ttInfo.score >= beta)) {
+            // Exact value
+            return updateMateDistanceOut(ttInfo.score);
+        } else if (ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta && !isPvNode) {
+            // Lower bound
+            return updateMateDistanceOut(ttInfo.score);
+        } else if (ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha && !isPvNode) {
+            // Upper bound
+            return updateMateDistanceOut(ttInfo.score);
         }
 
         hashMove = getTTableMove(ttInfo, gameState);

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -789,8 +789,8 @@ EvalT MoveSearcher::Impl::search(
         int depth,
         const int ply,
         EvalT alpha,
-        EvalT beta,
-        Move lastMove,
+        const EvalT beta,
+        const Move lastMove,
         const int lastNullMovePly,
         const NodeType nodeType,
         StackOfVectors<Move>& stack) {
@@ -901,7 +901,7 @@ EvalT MoveSearcher::Impl::search(
         //    PV nodes, so we don't want to use those values.
         if (ttInfo.depth >= depth) {
             if (ttInfo.scoreType == ScoreType::Exact
-                && (!isPvNode || ttInfo.score < alpha || ttInfo.score >= beta)) {
+                && (!isPvNode || ttInfo.score < alphaOrig || ttInfo.score >= beta)) {
                 // Exact value
                 return updateMateDistanceOut(ttInfo.score);
             } else if (
@@ -1157,7 +1157,7 @@ EvalT MoveSearcher::Impl::search(
 EvalT MoveSearcher::Impl::quiesce(
         GameState& gameState,
         EvalT alpha,
-        EvalT beta,
+        const EvalT beta,
         const int ply,
         const NodeType nodeType,
         StackOfVectors<Move>& stack) {
@@ -1247,7 +1247,7 @@ EvalT MoveSearcher::Impl::quiesce(
             return updateMateDistanceOut(ttInfo.score);
         } else if (
                 ttInfo.scoreType == ScoreType::Exact
-                && (!isPvNode || ttInfo.score < alpha || ttInfo.score >= beta)) {
+                && (!isPvNode || ttInfo.score < alphaOrig || ttInfo.score >= beta)) {
             // Exact value
             return updateMateDistanceOut(ttInfo.score);
         } else if (ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta && !isPvNode) {

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "pv-table-extract-only");
+            UciFrontEnd uciFrontEnd(engine, "more-tt-pv-cutoffs");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "more-tt-pv-cutoffs");
+            UciFrontEnd uciFrontEnd(engine, "more-tt-pv-cutoffs-alpha-orig");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
Allow TT cutoffs in PV nodes if the TT entry is exact and outside of alpha-beta bounds. This allows slightly more cutoffs, while still producing complete PVs.

Also fix bug where an aspiration search that failed high would get an outdated PV. This bugfix is probably responsible for most of the ELO gain.

```
--------------------------------------------------
Results of more-tt-pv-cutoffs-alpha-orig vs pv-table-extract-only (3+0.1, NULL, 512MB, UHO_2022_8mvs_big_+100_+129.pgn):
Elo: 3.32 +/- 4.65, nElo: 4.95 +/- 6.94
LOS: 91.90 %, DrawRatio: 41.22 %, PairsRatio: 1.06
Games: 9640, Wins: 2649, Losses: 2557, Draws: 4434, Points: 4866.0 (50.48 %)
Ptnml(0-2): [245, 1130, 1987, 1204, 254], WL/DD Ratio: 0.89
LLR: 2.97 (101.0%) (-2.94, 2.94) [-5.00, 0.00]
--------------------------------------------------
SPRT ([-5.00, 0.00]) completed - H1 was accepted

Using C:\Git\Euwe-chess-engine\Archive\more-tt-pv-cutoffs-alpha-orig.exe on .\matetrack.epd with --nodes 1000000
Engine ID:     more-tt-pv-cutoffs
Total FENs:    6554
Found mates:   742
Best mates:    694

Using C:\Git\Euwe-chess-engine\Archive\more-tt-pv-cutoffs-alpha-orig.exe on .\matedtrack.epd with --nodes 1000000
Engine ID:     more-tt-pv-cutoffs
Total FENs:    6536
Found mates:   1503
Best mates:    1436
```

Matetrack changes:
 - matetrack.epd, found: 740->72
 - matetrack.epd, best: 687->694
 - matedtrack.epd, found: 1494->1503
 - matedtrack.epd, best: 1430->1436