### PR TITLE
Allow NMP when the side-to-move is getting mated.

### DIFF
--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -310,8 +310,8 @@ namespace {
         const int depth,
         const int ply,
         const int lastNullMovePly) {
-    const bool basicConditions = !isPvNode && !isInCheck && !isMate(beta) && ply > 0 && depth >= 3
-                              && ply != lastNullMovePly + 2;
+    const bool basicConditions = !isPvNode && !isInCheck && (!isMate(beta) || beta < 0) && ply > 0
+                              && depth >= 3 && ply != lastNullMovePly + 2;
     if (!basicConditions) {
         return false;
     }

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "more-tt-pv-cutoffs-alpha-orig");
+            UciFrontEnd uciFrontEnd(engine, "nmp-when-mated");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
Counter-intuitively, this produces correct results, while the converse (NMP when side-to-move is mating) produces short PVs. Not sure why...

It's a pretty big jump in mate-finding ability. Before:
```
Using C:\Git\Euwe-chess-engine\Archive\more-tt-pv-cutoffs-alpha-orig.exe on .\matetrack.epd with --nodes 1000000
Engine ID:     more-tt-pv-cutoffs
Total FENs:    6554
Found mates:   742
Best mates:    694

Using C:\Git\Euwe-chess-engine\Archive\more-tt-pv-cutoffs-alpha-orig.exe on .\matedtrack.epd with --nodes 1000000
Engine ID:     more-tt-pv-cutoffs
Total FENs:    6536
Found mates:   1503
Best mates:    1436
```

Now:
```
Using C:\Git\Euwe-chess-engine\Archive\nmp-when-mated.exe on .\matetrack.epd with --nodes 1000000
Engine ID:     nmp-when-mated
Total FENs:    6554
Found mates:   1447
Best mates:    1218

Using C:\Git\Euwe-chess-engine\Archive\nmp-when-mated.exe on .\matedtrack.epd with --nodes 1000000
Engine ID:     nmp-when-mated
Total FENs:    6536
Found mates:   2194
Best mates:    2003
```