### PR TITLE
Consistently use `alphaOrig` in TT cutoff logic.

### DIFF
--- a/src/chess-engine-lib/EvalT.h
+++ b/src/chess-engine-lib/EvalT.h
@@ -56,5 +56,5 @@ inline constexpr EvalT kMateEval     = (EvalT)30'000;
 }
 
 [[nodiscard]] FORCE_INLINE constexpr EvalT clampNonMateEval(const int eval) {
-    return (EvalT)clamp((int)eval, -kMateEval + 1'000, kMateEval - 1'000);
+    return (EvalT)clamp(eval, -kMateEval + 1'000, kMateEval - 1'000);
 }

--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -914,10 +914,6 @@ EvalT MoveSearcher::Impl::search(
         }
 
         // See if we can return a value from the TT directly.
-        // We skip this step in PV nodes because:
-        //  - We want to get a full PV.
-        //  - The stored values may be heuristic bounds from pruning techniques that we disallow in
-        //    PV nodes, so we don't want to use those values.
         if (ttInfo.depth >= depth) {
             if (ttInfo.scoreType == ScoreType::Exact
                 && (!isPvNode || ttInfo.score < alphaOrig || ttInfo.score >= beta)) {
@@ -929,7 +925,7 @@ EvalT MoveSearcher::Impl::search(
                 // Lower bound
                 return updateMateDistanceOut(ttInfo.score);
             } else if (
-                    ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha
+                    ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alphaOrig
                     && !isPvNode) {
                 // Upper bound
                 return updateMateDistanceOut(ttInfo.score);
@@ -1273,7 +1269,9 @@ EvalT MoveSearcher::Impl::quiesce(
         } else if (ttInfo.scoreType == ScoreType::LowerBound && ttInfo.score >= beta && !isPvNode) {
             // Lower bound
             return updateMateDistanceOut(ttInfo.score);
-        } else if (ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alpha && !isPvNode) {
+        } else if (
+                ttInfo.scoreType == ScoreType::UpperBound && ttInfo.score < alphaOrig
+                && !isPvNode) {
             // Upper bound
             return updateMateDistanceOut(ttInfo.score);
         }


### PR DESCRIPTION
Note that this does not change semantics, since the distinction only matters in non-PV nodes, but the changed condition only matters in PV nodes.

However, this way of writing it is more consistent and less confusing.