### PR TITLE
Better mate distance pruning.

### DIFF
--- a/src/chess-engine-lib/MoveSearcher.cpp
+++ b/src/chess-engine-lib/MoveSearcher.cpp
@@ -835,11 +835,11 @@ EvalT MoveSearcher::Impl::search(
 
     // Mate distance pruning: check for impossible mate
     static constexpr EvalT kBestCaseMate = mateIn(1);
-    if (kBestCaseMate < alpha) {
+    if (kBestCaseMate <= alpha) {
         return updateMateDistanceOut(kBestCaseMate);
     }
     const EvalT worstCaseMate = isInCheck ? -kMateEval : -mateIn(2);
-    if (worstCaseMate > beta) {
+    if (worstCaseMate >= beta) {
         return updateMateDistanceOut(worstCaseMate);
     }
 

--- a/src/chess-engine/Main.cpp
+++ b/src/chess-engine/Main.cpp
@@ -23,7 +23,7 @@ int main() try {
 
         if (command == "uci") {
             Engine engine;
-            UciFrontEnd uciFrontEnd(engine, "mate-futility-pruning");
+            UciFrontEnd uciFrontEnd(engine, "mdp-equal");
             uciFrontEnd.run();
             break;
         } else if (command == "perft") {


### PR DESCRIPTION
MDP was leaving opportunities on the table when the best/worst possible mate was equal to the alpha-beta bounds.

Matetrack shows a nice improvement.

Before:
```
Using C:\Git\Euwe-chess-engine\Archive\mate-futility-pruning.exe on .\matetrack.epd with --nodes 1000000
Engine ID:     mate-futility-pruning
Total FENs:    6554
Found mates:   2077
Best mates:    1618

Using C:\Git\Euwe-chess-engine\Archive\mate-futility-pruning.exe on .\matedtrack.epd with --nodes 1000000
Engine ID:     mate-futility-pruning
Total FENs:    6536
Found mates:   2707
Best mates:    2360
```

Now:
```
Using C:\Git\Euwe-chess-engine\Archive\mdp-equal.exe on .\matetrack.epd with --nodes 1000000
Engine ID:     mdp-equal
Total FENs:    6554
Found mates:   2096
Best mates:    1663

Using C:\Git\Euwe-chess-engine\Archive\mdp-equal.exe on .\matedtrack.epd with --nodes 1000000
Engine ID:     mdp-equal
Total FENs:    6536
Found mates:   2720
Best mates:    2401
```