### PR TITLE
Remove release modes from E2E tests.

### DIFF
--- a/.github/workflows/e2e-engine-tests.yml
+++ b/.github/workflows/e2e-engine-tests.yml
@@ -41,11 +41,6 @@ jobs:
           # Windows clang-cl
           - {
               os: windows-2025,
-              preset: windows-clang-cl-release,
-              big_bench: true,
-            }
-          - {
-              os: windows-2025,
               preset: windows-clang-cl-pgo,
               big_bench: true,
             }
@@ -55,11 +50,6 @@ jobs:
               os: ubuntu-latest,
               preset: linux-clang-debug,
               big_bench: false,
-            }
-          - {
-              os: ubuntu-latest,
-              preset: linux-clang-release,
-              big_bench: true,
             }
           - {
               os: ubuntu-latest,


### PR DESCRIPTION
Remove release (non-pgo) linux and windows clang(-cl) build modes from E2E tests. These tests are still included in the unit tests.

This helps reduce E2E CI pressure a bit.